### PR TITLE
docs: add mandatory PR workflow rules to cursor rules

### DIFF
--- a/.cursor/rules/architecture.md
+++ b/.cursor/rules/architecture.md
@@ -222,9 +222,35 @@ if (!accessToken) return; // signed out during fetch
 - **User-friendly errors.** Never show raw API errors. Always parse through `parseError()` and show actionable guidance.
 - **Accessibility.** Svelte a11y warnings on the modal overlay are suppressed with `<!-- svelte-ignore -->` comments. Escape key closes the modal via a window-level keydown listener.
 
-## GitHub
+## Git Workflow
+
+### Branch & PR policy (MANDATORY)
+
+- **NEVER push directly to `main`.**
+- **Every feature, refactor, bug fix, or docs update** must go through a pull request.
+- If no feature branch exists yet, create one before committing (e.g. `feature/component-refactoring`, `fix/base64-padding`, `docs/update-rules`).
+- Branch naming: `feature/*`, `fix/*`, `refactor/*`, `docs/*`, `chore/*`.
+- Open a PR using `gh pr create` with a clear summary and test plan.
+- Wait for review (bugbot or human) before merging.
+- The **only** exception to pushing directly to `main` is if the user explicitly says "push to main without a PR".
+
+### PR requirements
+
+- **Title**: concise, describes the change (e.g. "refactor: extract Chat into smaller components").
+- **Body**: must include a `## Summary` section with 1-3 bullet points explaining what changed and why, and a `## Test plan` section with verification steps.
+- Always push the branch with `git push -u origin HEAD` before creating the PR.
+- Use `gh pr create` — never create PRs through other means.
+- Return the PR URL to the user when done.
+
+### Commit conventions
+
+- Use conventional commit prefixes: `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`.
+- Keep commits focused — one logical change per commit.
+- Write commit messages that explain **why**, not just **what**.
+
+### Repository
 
 - Repo: `cypherkitty/me-ai` (private)
-- Branch: `main`
+- Default branch: `main`
 - CI: None configured yet
 - PR reviews: bugbot (automated) provides code review on PRs


### PR DESCRIPTION
## Summary
- Add a **Git Workflow** section to `architecture.md` with mandatory branch & PR policy
- Codify rules: never push to `main` directly, always use feature branches, always open PRs with summary + test plan
- Include branch naming conventions (`feature/*`, `fix/*`, `refactor/*`, `docs/*`, `chore/*`) and conventional commit prefixes

## Test plan
- [ ] Verify the rules render correctly in `.cursor/rules/architecture.md`
- [ ] Confirm agent follows the workflow in future tasks

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that affect process guidance, not runtime code or data/security behavior.
> 
> **Overview**
> Adds a new **Git Workflow** section to `.cursor/rules/architecture.md` that *mandates* PR-based development (no direct pushes to `main`), including branch naming guidance and requiring PRs to be created via `gh pr create` with a `## Summary` and `## Test plan`.
> 
> Also documents conventional commit prefixes and clarifies repository metadata (e.g., default branch).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfe2f0de214bb2ee7f39c2bdfc557dda7ca24960. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->