### PR TITLE
fix: add /me-ai/ subpath to OAuth redirect URIs

### DIFF
--- a/src/components/dashboard/SetupGuide.svelte
+++ b/src/components/dashboard/SetupGuide.svelte
@@ -27,7 +27,8 @@
   }
 
   const LOCALHOST = "http://localhost:5173";
-  const PAGES = "https://cypherkitty.github.io";
+  const PAGES_ORIGIN = "https://cypherkitty.github.io";
+  const PAGES_APP = "https://cypherkitty.github.io/me-ai/";
 </script>
 
 <div class="setup-container">
@@ -75,35 +76,41 @@
           <p class="step-label">Add these URLs to your OAuth client. Click to copy:</p>
 
           <div class="url-section">
-            <span class="url-section-title">Authorized JavaScript origins:</span>
+            <span class="url-section-title">Authorized JavaScript origins (no trailing slash):</span>
             <div class="url-chips">
               <button class="url-chip" onclick={() => copy(LOCALHOST)}>
                 <code>{LOCALHOST}</code>
                 <span class="copy-icon">{copiedField === LOCALHOST ? "✓" : "⧉"}</span>
               </button>
-              <button class="url-chip" onclick={() => copy(PAGES)}>
-                <code>{PAGES}</code>
-                <span class="copy-icon">{copiedField === PAGES ? "✓" : "⧉"}</span>
+              <button class="url-chip" onclick={() => copy(PAGES_ORIGIN)}>
+                <code>{PAGES_ORIGIN}</code>
+                <span class="copy-icon">{copiedField === PAGES_ORIGIN ? "✓" : "⧉"}</span>
               </button>
             </div>
           </div>
 
           <div class="url-section">
-            <span class="url-section-title">Authorized redirect URIs:</span>
+            <span class="url-section-title">Authorized redirect URIs (add all three):</span>
             <div class="url-chips">
               <button class="url-chip" onclick={() => copy(LOCALHOST)}>
                 <code>{LOCALHOST}</code>
                 <span class="copy-icon">{copiedField === LOCALHOST ? "✓" : "⧉"}</span>
               </button>
-              <button class="url-chip" onclick={() => copy(PAGES)}>
-                <code>{PAGES}</code>
-                <span class="copy-icon">{copiedField === PAGES ? "✓" : "⧉"}</span>
+              <button class="url-chip" onclick={() => copy(PAGES_ORIGIN)}>
+                <code>{PAGES_ORIGIN}</code>
+                <span class="copy-icon">{copiedField === PAGES_ORIGIN ? "✓" : "⧉"}</span>
+              </button>
+              <button class="url-chip" onclick={() => copy(PAGES_APP)}>
+                <code>{PAGES_APP}</code>
+                <span class="copy-icon">{copiedField === PAGES_APP ? "✓" : "⧉"}</span>
               </button>
             </div>
           </div>
 
           <p class="step-hint">
-            Both localhost (for development) and GitHub Pages (for production) are needed.
+            Both localhost (dev) and GitHub Pages (prod) are needed. The /me-ai/ path
+            is required because the app is deployed at a subpath. Changes may take a
+            few minutes to propagate after saving.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Adds `https://cypherkitty.github.io/me-ai/` as a redirect URI in the setup guide — the subpath is required because Google checks the full redirect path, not just the origin
- Clarifies that JavaScript origins must not have trailing slashes
- Adds note that Google Cloud Console changes may take a few minutes to propagate

Fixes `Error 400: redirect_uri_mismatch` when signing in from GitHub Pages.

## Test plan
- [ ] Navigate to Dashboard setup guide and verify all 3 redirect URIs are listed
- [ ] Copy each URL chip and verify correct value is in clipboard
- [ ] After updating Google Cloud Console with all URIs, verify OAuth sign-in works from GitHub Pages

Made with [Cursor](https://cursor.com)