### PR TITLE
feat: export Gmail messages as Markdown files

### DIFF
--- a/src/components/dashboard/MessageModal.svelte
+++ b/src/components/dashboard/MessageModal.svelte
@@ -1,11 +1,18 @@
 <script>
   import { onMount } from "svelte";
   import { formatDate } from "../../lib/email-utils.js";
+  import { emailToMarkdown, emailFilename, downloadText } from "../../lib/markdown-export.js";
   import { mountLog } from "../../lib/debug.js";
 
   let { message, loading = false, onclose } = $props();
 
   onMount(() => mountLog("MessageModal"));
+
+  function exportMarkdown() {
+    const md = emailToMarkdown(message);
+    const filename = emailFilename(message);
+    downloadText(md, filename);
+  }
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
@@ -18,7 +25,14 @@
   <div class="modal-content" onclick={(e) => e.stopPropagation()} role="document">
     <div class="modal-header">
       <h3 class="modal-subject">{message.subject}</h3>
-      <button class="modal-close" onclick={onclose}>✕</button>
+      <div class="header-actions">
+        {#if message.body}
+          <button class="action-btn" onclick={exportMarkdown} title="Export as Markdown">
+            .md
+          </button>
+        {/if}
+        <button class="modal-close" onclick={onclose}>✕</button>
+      </div>
     </div>
     <div class="modal-meta">
       <div class="meta-row">
@@ -83,6 +97,28 @@
     font-size: 1.1rem;
     font-weight: 600;
     line-height: 1.4;
+  }
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-shrink: 0;
+  }
+  .action-btn {
+    background: #1a1a1a;
+    border: 1px solid #333;
+    border-radius: 5px;
+    color: #aaa;
+    font-size: 0.7rem;
+    font-weight: 600;
+    font-family: monospace;
+    cursor: pointer;
+    padding: 0.25rem 0.5rem;
+    transition: border-color 0.15s, color 0.15s;
+  }
+  .action-btn:hover {
+    border-color: #3b82f6;
+    color: #e8e8e8;
   }
   .modal-close {
     background: none;

--- a/src/lib/markdown-export.js
+++ b/src/lib/markdown-export.js
@@ -1,0 +1,79 @@
+import { formatDate } from "./email-utils.js";
+
+/**
+ * Convert a parsed email message to Markdown format.
+ *
+ * @param {{ subject: string, from: string, to: string, date: string, body: string | null }} message
+ * @returns {string} Markdown-formatted email
+ */
+export function emailToMarkdown(message) {
+  const lines = [];
+
+  lines.push(`# ${message.subject}`);
+  lines.push("");
+  lines.push(`| | |`);
+  lines.push(`|---|---|`);
+  lines.push(`| **From** | ${escapeCell(message.from)} |`);
+  lines.push(`| **To** | ${escapeCell(message.to)} |`);
+  lines.push(`| **Date** | ${formatDate(message.date)} |`);
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+  lines.push(message.body || "*(no body)*");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/** Escape pipe characters inside a Markdown table cell */
+function escapeCell(text) {
+  return (text || "").replace(/\|/g, "\\|");
+}
+
+/**
+ * Generate a safe filename from an email subject.
+ * Strips characters that are invalid in filenames.
+ *
+ * @param {{ subject: string, date: string }} message
+ * @returns {string} filename ending in .md
+ */
+export function emailFilename(message) {
+  const datePrefix = shortDate(message.date);
+  const slug = (message.subject || "email")
+    .replace(/[^a-zA-Z0-9 _-]/g, "")
+    .replace(/\s+/g, "-")
+    .slice(0, 60)
+    .replace(/-+$/, "");
+
+  return `${datePrefix}_${slug}.md`;
+}
+
+function shortDate(dateStr) {
+  try {
+    const d = new Date(dateStr);
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${y}-${m}-${day}`;
+  } catch {
+    return "email";
+  }
+}
+
+/**
+ * Trigger a browser download of the given text as a file.
+ *
+ * @param {string} content  File contents
+ * @param {string} filename Suggested filename
+ */
+export function downloadText(content, filename) {
+  const blob = new Blob([content], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- New `.md` button in the message modal header to download the email as a Markdown file
- Markdown output includes a metadata table (From, To, Date) and the full message body
- Filenames are auto-generated from date + subject (e.g. `2026-02-14_Amazon-feedback.md`)
- New utility module `src/lib/markdown-export.js` with `emailToMarkdown()`, `emailFilename()`, and `downloadText()`

## Example output

```markdown
# Viacheslav Petc, will you rate your transaction at Amazon.com?

| | |
|---|---|
| **From** | Amazon Marketplace <marketplace-messages@amazon.com> |
| **To** | viacheslav.petc@gmail.com |
| **Date** | Feb 14, 2026, 12:52 PM |

---

Dear Viacheslav Petc, Will you share your experience? ...
```

## Test plan
- [ ] Sign in to Gmail Dashboard, open a message
- [ ] Verify `.md` button appears in the modal header (only when body is loaded)
- [ ] Click the button and verify a `.md` file is downloaded
- [ ] Open the file and verify formatting (title, metadata table, body)
- [ ] Verify the button doesn't appear while the message is still loading

Made with [Cursor](https://cursor.com)