### PR TITLE
feat: render HTML emails with images + markdown preview modal

### DIFF
--- a/src/Dashboard.svelte
+++ b/src/Dashboard.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from "svelte";
   import { initGoogleAuth, requestAccessToken, revokeToken } from "./lib/google-auth.js";
-  import { getProfile, listMessages, getMessagesBatch, getBody } from "./lib/gmail-api.js";
+  import { getProfile, listMessages, getMessagesBatch, getBody, getHtmlBody } from "./lib/gmail-api.js";
   import { parseMessage } from "./lib/email-utils.js";
   import SetupGuide from "./components/dashboard/SetupGuide.svelte";
   import AuthCard from "./components/dashboard/AuthCard.svelte";
@@ -160,9 +160,10 @@
         const full = await getMessage(accessToken, msg.id, "full");
         if (!accessToken) return;
         const body = getBody(full);
-        selectedMessage = { ...msg, body };
+        const htmlBody = getHtmlBody(full);
+        selectedMessage = { ...msg, body, htmlBody };
         emailMessages = emailMessages.map((m) =>
-          m.id === msg.id ? { ...m, body } : m
+          m.id === msg.id ? { ...m, body, htmlBody } : m
         );
       } catch (e) {
         if (!accessToken) return;

--- a/src/lib/gmail-api.js
+++ b/src/lib/gmail-api.js
@@ -114,6 +114,27 @@ export function getBody(message) {
   return "(no body)";
 }
 
+/**
+ * Extract raw HTML body from a Message resource.
+ * Returns the HTML string if available, or null if only plain text.
+ */
+export function getHtmlBody(message) {
+  const payload = message?.payload;
+  if (!payload) return null;
+
+  // Simple (non-multipart) message — check if it's HTML
+  if (payload.mimeType === "text/html" && payload.body?.data) {
+    return decodeBase64Url(payload.body.data);
+  }
+
+  // Multipart: find HTML part
+  const parts = payload.parts || [];
+  const html = findPart(parts, "text/html");
+  if (html?.body?.data) return decodeBase64Url(html.body.data);
+
+  return null;
+}
+
 function findPart(parts, mimeType) {
   for (const part of parts) {
     if (part.mimeType === mimeType) return part;


### PR DESCRIPTION
## Summary
- **HTML email rendering**: Emails are now displayed in a sandboxed `<iframe>` preserving images, formatting, links, and layout — matching how they look in Gmail
- **Markdown preview modal**: The `.md` button now toggles an in-modal view with Raw/Preview tabs instead of downloading a file. A Download button is still available in the toolbar
- New `getHtmlBody()` function in `gmail-api.js` extracts raw HTML from Gmail messages

## How it works

### HTML rendering
- `getHtmlBody()` extracts the `text/html` MIME part from Gmail messages
- Both `body` (plain text) and `htmlBody` (raw HTML) are stored on the message object
- HTML is rendered in an `<iframe sandbox="allow-same-origin">` — scripts are blocked, but images and CSS work
- The iframe gets a dark-themed base stylesheet injected for consistent appearance
- Falls back to plain `<pre>` text if no HTML body is available

### Markdown preview
- Clicking `.md` toggles between email view and markdown view
- **Raw tab**: monospace code view of the generated markdown
- **Preview tab**: lightweight markdown-to-HTML renderer for headings, tables, bold, italic, horizontal rules
- **Download button**: still allows saving the `.md` file to disk

## Test plan
- [ ] Open an HTML email (e.g. Amazon delivery) — verify images and formatting render correctly
- [ ] Open a plain text email — verify it still displays as pre-formatted text
- [ ] Click `.md` button — verify it toggles to markdown view (not download)
- [ ] Switch between Raw and Preview tabs
- [ ] Click Download in the markdown toolbar — verify `.md` file downloads
- [ ] Click `.md` again — verify it returns to email view
- [ ] Existing unit tests still pass

Made with [Cursor](https://cursor.com)