### PR TITLE
fix: markdown preview rendering + tracking pixel filter + unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,177 @@
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "jsdom": "^27.0.1",
         "svelte": "^5.0.0",
         "vite": "^6.2.0",
         "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
+      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1650,6 +1818,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -1678,6 +1856,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/boolean": {
@@ -1743,6 +1931,60 @@
         "node": ">=6"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1760,6 +2002,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -1836,6 +2085,19 @@
       "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -2061,6 +2323,67 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -2077,6 +2400,46 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+      "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.7.2",
+        "cssstyle": "^5.3.1",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -2114,6 +2477,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2135,6 +2508,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/minipass": {
       "version": "7.1.2",
@@ -2235,6 +2615,19 @@
       "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -2331,6 +2724,26 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/roarr": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -2391,6 +2804,33 @@
         "@rollup/rollup-win32-x64-gnu": "4.57.1",
         "@rollup/rollup-win32-x64-msvc": "4.57.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -2548,6 +2988,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar": {
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
@@ -2623,6 +3070,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -2841,6 +3334,67 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2857,6 +3411,45 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "jsdom": "^27.0.1",
     "svelte": "^5.0.0",
     "vite": "^6.2.0",
     "vitest": "^3.2.4"

--- a/src/components/dashboard/MessageModal.svelte
+++ b/src/components/dashboard/MessageModal.svelte
@@ -26,6 +26,10 @@
   // ── Render markdown to simple HTML for preview ────────────────────
   function renderMarkdown(md) {
     return md
+      // Images: ![alt](url)
+      .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1" style="max-width:100%;height:auto;border-radius:4px;margin:0.5rem 0">')
+      // Links: [text](url)
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener" style="color:#60a5fa">$1</a>')
       // H1
       .replace(/^# (.+)$/gm, "<h1>$1</h1>")
       // Bold
@@ -37,9 +41,7 @@
       // Table rows: | cell | cell |
       .replace(/^\|(.+)\|$/gm, (_, cells) => {
         const tds = cells.split("|").map(c => c.trim());
-        // Skip separator rows like |---|---|
         if (tds.every(td => /^-+$/.test(td))) return "";
-        const tag = tds.some(td => /^\*\*/.test(td)) ? "td" : "td";
         return "<tr>" + tds.map(td => `<td>${td}</td>`).join("") + "</tr>";
       })
       // Wrap consecutive <tr> in <table>

--- a/src/lib/__tests__/html-to-markdown.test.js
+++ b/src/lib/__tests__/html-to-markdown.test.js
@@ -1,0 +1,220 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from "vitest";
+import { emailToMarkdown, htmlToMarkdownBody } from "../markdown-export.js";
+
+// ── Realistic Amazon delivery email HTML (simplified) ───────────────
+
+const AMAZON_DELIVERY_HTML = `
+<html>
+<head><style>.header { background: #232f3e; }</style></head>
+<body>
+  <table width="100%">
+    <tr><td>
+      <a href="https://www.amazon.com/gp/r.html?C=ABC123&M=urn:rtn:msg:2026&ref_=pe_orders">
+        <img src="https://www.amazon.com/gp/r.html?C=ABC123&M=urn:rtn:msg:2026&H=xyz&ref_=pe_logo"
+             alt="" width="1" height="1">
+      </a>
+      <table>
+        <tr>
+          <td>
+            <a href="https://www.amazon.com/your-orders">Your Orders</a>
+            <a href="https://www.amazon.com/your-account">Your Account</a>
+            <a href="https://www.amazon.com/buy-again">Buy Again</a>
+          </td>
+        </tr>
+      </table>
+      <h1>Your package was delivered!</h1>
+      <img src="https://images-na.ssl-images-amazon.com/images/G/01/shiptrack/delivered_photo_123.jpg"
+           alt="Delivery photo" width="400" height="300">
+      <p>
+        <b>Delivered today</b><br>
+        Your package was left near the front door or porch.
+      </p>
+      <p>
+        <b>Elon - HAWTHORNE, CA</b><br>
+        Order # 000-1234567-8901234
+      </p>
+      <a href="https://www.amazon.com/progress-tracker/package?orderId=000-1234567-8901234">
+        <img src="https://images-na.ssl-images-amazon.com/images/G/01/shiptrack/track_btn.png"
+             alt="Track package" width="150" height="40">
+      </a>
+      <table>
+        <tr>
+          <td>
+            <img src="https://images-na.ssl-images-amazon.com/images/I/product_image.jpg"
+                 alt="MooMee Bedding Duvet Cover" width="100" height="100">
+          </td>
+          <td>
+            * MooMee Bedding Duvet Cover Set 100% Washed Cotton Linen Like
+          </td>
+        </tr>
+      </table>
+      <img src="https://www.amazon.com/gp/r.html?C=ABC&K=XYZ&M=urn:rtn:msg:2026&ref_=pe_img"
+           alt="" width="600" height="1">
+      <img src="https://images-na.ssl-images-amazon.com/images/G/01/nav/transp.gif"
+           alt="" width="1" height="1">
+    </td></tr>
+  </table>
+</body>
+</html>
+`;
+
+// ── Simple HTML with images and links ───────────────────────────────
+
+const SIMPLE_HTML_WITH_IMAGES = `
+<html><body>
+  <h1>Newsletter</h1>
+  <p>Check out our new product:</p>
+  <img src="https://example.com/product.jpg" alt="New Product">
+  <p>Visit <a href="https://example.com">our website</a> for more.</p>
+</body></html>
+`;
+
+const PLAIN_TEXT_ONLY_HTML = `
+<html><body>
+  <p>Hello, this is a plain text email with no images.</p>
+  <p>Best regards,<br>John</p>
+</body></html>
+`;
+
+const TRACKING_PIXEL_HTML = `
+<html><body>
+  <p>Hello World</p>
+  <img src="https://tracker.example.com/pixel.gif" width="1" height="1" alt="">
+  <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP" alt="">
+  <img src="https://example.com/spacer.gif" width="1" height="1" alt="">
+  <img src="https://example.com/real-image.jpg" width="600" height="400" alt="Photo">
+</body></html>
+`;
+
+// ── htmlToMarkdownBody tests ────────────────────────────────────────
+
+describe("htmlToMarkdownBody", () => {
+  it("converts basic HTML with image to markdown", () => {
+    const md = htmlToMarkdownBody(SIMPLE_HTML_WITH_IMAGES);
+    expect(md).toContain("# Newsletter");
+    expect(md).toContain("![New Product](https://example.com/product.jpg)");
+    expect(md).toContain("[our website](https://example.com)");
+  });
+
+  it("converts paragraphs and line breaks", () => {
+    const md = htmlToMarkdownBody(PLAIN_TEXT_ONLY_HTML);
+    expect(md).toContain("Hello, this is a plain text email with no images.");
+    expect(md).toContain("Best regards,");
+    expect(md).toContain("John");
+  });
+
+  it("skips tracking pixels (1x1 images)", () => {
+    const md = htmlToMarkdownBody(TRACKING_PIXEL_HTML);
+    expect(md).toContain("Hello World");
+    expect(md).not.toContain("pixel.gif");
+    expect(md).not.toContain("spacer.gif");
+    expect(md).not.toContain("data:image");
+    // Real image should be kept
+    expect(md).toContain("![Photo](https://example.com/real-image.jpg)");
+  });
+
+  it("preserves bold text", () => {
+    const md = htmlToMarkdownBody("<p><b>Important</b> text</p>");
+    expect(md).toContain("**Important**");
+  });
+
+  it("preserves italic text", () => {
+    const md = htmlToMarkdownBody("<p><em>Emphasized</em> text</p>");
+    expect(md).toContain("*Emphasized*");
+  });
+
+  it("converts headings at all levels", () => {
+    const md = htmlToMarkdownBody("<h1>One</h1><h2>Two</h2><h3>Three</h3>");
+    expect(md).toContain("# One");
+    expect(md).toContain("## Two");
+    expect(md).toContain("### Three");
+  });
+
+  it("converts horizontal rules", () => {
+    const md = htmlToMarkdownBody("<p>Before</p><hr><p>After</p>");
+    expect(md).toContain("---");
+  });
+
+  it("strips style and script tags", () => {
+    const md = htmlToMarkdownBody(
+      "<style>.red { color: red }</style><script>alert(1)</script><p>Content</p>"
+    );
+    expect(md).not.toContain(".red");
+    expect(md).not.toContain("alert");
+    expect(md).toContain("Content");
+  });
+
+  it("handles Amazon delivery email — keeps real images, skips tracking", () => {
+    const md = htmlToMarkdownBody(AMAZON_DELIVERY_HTML);
+
+    // Real content should be present
+    expect(md).toContain("Your package was delivered!");
+    expect(md).toContain("**Delivered today**");
+    expect(md).toContain("HAWTHORNE, CA");
+    expect(md).toContain("000-1234567-8901234");
+
+    // Real images should be preserved
+    expect(md).toContain("![Delivery photo](https://images-na.ssl-images-amazon.com/images/G/01/shiptrack/delivered_photo_123.jpg)");
+    expect(md).toContain("![MooMee Bedding Duvet Cover](https://images-na.ssl-images-amazon.com/images/I/product_image.jpg)");
+
+    // Tracking pixels and spacers should be filtered out
+    expect(md).not.toContain("transp.gif");
+    // 1x1 tracking pixel should be filtered
+    expect(md).not.toMatch(/!\[\]\(https:\/\/www\.amazon\.com\/gp\/r\.html\?C=ABC123/);
+
+    // Links should be preserved
+    expect(md).toContain("[Your Orders](https://www.amazon.com/your-orders)");
+    expect(md).toContain("[Your Account](https://www.amazon.com/your-account)");
+  });
+
+  it("handles empty HTML", () => {
+    const md = htmlToMarkdownBody("<html><body></body></html>");
+    expect(md).toBe("");
+  });
+
+  it("handles images inside links", () => {
+    const md = htmlToMarkdownBody(
+      '<a href="https://example.com"><img src="https://example.com/banner.jpg" alt="Banner"></a>'
+    );
+    // Should contain the image (link wrapping may vary but image must be present)
+    expect(md).toContain("![Banner](https://example.com/banner.jpg)");
+  });
+});
+
+// ── emailToMarkdown with htmlBody ───────────────────────────────────
+
+describe("emailToMarkdown with htmlBody", () => {
+  const MESSAGE_WITH_HTML = {
+    subject: "Delivered: MooMee Bedding Duvet Cover",
+    from: '"Amazon.com" <order-update@amazon.com>',
+    to: "elon@spacex.com",
+    date: "Fri, 14 Feb 2026 17:14:00 +0000",
+    body: "Your package was delivered! Delivered today",
+    htmlBody: SIMPLE_HTML_WITH_IMAGES,
+  };
+
+  it("uses htmlBody when available instead of plain text body", () => {
+    const md = emailToMarkdown(MESSAGE_WITH_HTML);
+    // Should use the HTML conversion (has image) not the plain text
+    expect(md).toContain("![New Product](https://example.com/product.jpg)");
+  });
+
+  it("falls back to plain text body when no htmlBody", () => {
+    const msg = { ...MESSAGE_WITH_HTML, htmlBody: null };
+    const md = emailToMarkdown(msg);
+    expect(md).toContain("Your package was delivered! Delivered today");
+    expect(md).not.toContain("![");
+  });
+
+  it("still includes metadata table", () => {
+    const md = emailToMarkdown(MESSAGE_WITH_HTML);
+    expect(md).toContain("# Delivered: MooMee Bedding Duvet Cover");
+    expect(md).toContain("| **From** |");
+    expect(md).toContain("| **To** |");
+    expect(md).toContain("| **Date** |");
+    expect(md).toContain("---");
+  });
+});

--- a/src/lib/__tests__/markdown-export.test.js
+++ b/src/lib/__tests__/markdown-export.test.js
@@ -12,11 +12,11 @@ const BASIC_MESSAGE = {
 };
 
 const AMAZON_MESSAGE = {
-  subject: "Viacheslav Petc, will you rate your transaction at Amazon.com?",
+  subject: "Elon Musk, will you rate your transaction at Amazon.com?",
   from: "Amazon Marketplace <marketplace-messages@amazon.com>",
-  to: "viacheslav.petc@gmail.com",
+  to: "elon@spacex.com",
   date: "Sat, 14 Feb 2026 12:52:00 +0000",
-  body: "Dear Viacheslav Petc,\nWill you share your experience?",
+  body: "Dear Elon Musk,\nWill you share your experience?",
 };
 
 // ── emailToMarkdown ─────────────────────────────────────────────────────
@@ -89,7 +89,7 @@ describe("emailToMarkdown", () => {
 
     // H1
     expect(lines[0]).toBe(
-      "# Viacheslav Petc, will you rate your transaction at Amazon.com?"
+      "# Elon Musk, will you rate your transaction at Amazon.com?"
     );
     // blank line
     expect(lines[1]).toBe("");
@@ -105,7 +105,7 @@ describe("emailToMarkdown", () => {
     expect(lines[8]).toBe("---");
     expect(lines[9]).toBe("");
     // body
-    expect(lines[10]).toBe("Dear Viacheslav Petc,");
+    expect(lines[10]).toBe("Dear Elon Musk,");
   });
 });
 


### PR DESCRIPTION
## Summary
- **Fix Preview tab**: `renderMarkdown()` now handles `![alt](url)` images and `[text](url)` links — previously showed raw markdown syntax instead of rendered content
- **Filter tracking pixels**: New `isSkippableImage()` filters out 1x1 pixels, spacer GIFs, `data:` URIs, and Amazon tracking redirect URLs from markdown export
- **14 new unit tests** with jsdom for HTML-to-markdown conversion, including a realistic Amazon delivery email fixture

## What was broken
The Preview tab in the markdown modal was showing raw `![](url)` and `[text](url)` syntax instead of rendered images and links. Additionally, Amazon emails include dozens of 1x1 tracking pixels that cluttered the markdown output.

## Tracking pixel detection
Images are filtered when any of these are true:
- No `src` or `data:` URI
- `width` or `height` attribute is 1-3px
- URL contains `spacer`, `transparent`, or `transp.gif`
- Amazon redirect URL (`/gp/r.html?`) wrapping a transparent image

## Test coverage (14 new tests)
- Basic HTML with images → markdown
- Paragraphs and line breaks
- Tracking pixel filtering (1x1, data:, spacer)
- Bold, italic, headings, horizontal rules
- Style/script stripping
- **Realistic Amazon delivery email** — keeps delivery photo + product image, filters tracking pixels
- Empty HTML
- Images inside links
- `emailToMarkdown` with/without `htmlBody`
- Metadata table preservation

## Test plan
- [x] All 32 tests pass (18 existing + 14 new)
- [ ] Open Amazon delivery email → `.md` → Preview tab shows images rendered
- [ ] Raw tab shows clean `![alt](url)` syntax without tracking pixel noise
- [ ] Download still works correctly

Made with [Cursor](https://cursor.com)