### PR TITLE
fix: replace hand-rolled markdown renderer with marked + DOMPurify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "me-ai",
       "version": "0.0.0",
       "dependencies": {
-        "@huggingface/transformers": "^3.8.0"
+        "@huggingface/transformers": "^3.8.0",
+        "dompurify": "^3.3.1",
+        "marked": "^17.0.2"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
@@ -1687,7 +1689,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
@@ -2085,6 +2087,15 @@
       "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -2495,6 +2506,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.2.tgz",
+      "integrity": "sha512-s5HZGFQea7Huv5zZcAGhJLT3qLpAfnY7v7GWkICUr0+Wd5TFEtdlRR2XUL5Gg+RH7u2Df595ifrxR03mBaw7gA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/matcher": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@huggingface/transformers": "^3.8.0"
+    "@huggingface/transformers": "^3.8.0",
+    "dompurify": "^3.3.1",
+    "marked": "^17.0.2"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.0.0",


### PR DESCRIPTION
## Summary
- Replaced the fragile regex-based `renderMarkdown()` with **[marked](https://www.npmjs.com/package/marked)** (26M+ weekly downloads), a proper GFM-compliant markdown-to-HTML renderer that handles complex URLs, tables, images, links, code blocks, and all standard markdown syntax
- Added **[DOMPurify](https://www.npmjs.com/package/dompurify)** to sanitize the rendered HTML before injecting via `{@html}`, preventing XSS
- Broadened the tracking pixel filter: any `<img>` with `src` matching `amazon.com/gp/r.html?` is now skipped (previously required additional `transp|spacer|nav%2F` match)
- Added comprehensive CSS styles for `.md-preview` to properly style all markdown elements (headings, links, images, code, blockquotes, lists, tables)
- Links in the preview now open in a new tab via custom marked renderer

## Test plan
- [x] Build succeeds
- [x] All 32 existing unit tests pass
- [ ] Open an Amazon delivery email → click .md → Preview tab renders images, links, tables, headings correctly
- [ ] Verify tracking pixel URLs are filtered out of markdown output
- [ ] Verify no raw `![](url)` or `[text](url)` syntax appears in Preview


Made with [Cursor](https://cursor.com)