### PR TITLE
docs: add merge-pr skill and update workflow rules

### DIFF
--- a/.cursor/rules/workflow.md
+++ b/.cursor/rules/workflow.md
@@ -43,9 +43,12 @@ test/*       — test additions (test/markdown-export)
 
 ### Merging (MANDATORY — all checks must pass before merge)
 
-1. **CI must pass** — verify with `gh pr checks <PR_NUMBER>`. Do NOT merge if any check is failing or pending.
-2. **All PR comments must be addressed** — check with `gh api repos/{owner}/{repo}/pulls/{N}/comments`. Resolve every comment before merging. If a comment requests changes, make the fix, push, and verify CI again.
-3. **ALWAYS squash merge** — use `gh pr merge N --squash`. Never use regular merge or rebase merge. Squash keeps `main` history clean with one commit per feature/fix.
+**For the full step-by-step merge procedure, use the `merge-pr` skill (`.cursor/skills/merge-pr/SKILL.md`).**
+
+Core rules (non-negotiable):
+1. **CI must pass** — do NOT merge if any check is failing or pending.
+2. **All PR comments must be addressed** — resolve every comment before merging.
+3. **ALWAYS squash merge** — `gh pr merge N --squash`. Never regular merge or rebase. Squash keeps `main` history clean with one commit per feature/fix.
 4. After merge, the deploy workflow auto-triggers for `main` pushes.
 5. Pull latest main after merging: `git checkout main && git pull`
 

--- a/.cursor/skills/merge-pr/SKILL.md
+++ b/.cursor/skills/merge-pr/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: merge-pr
+description: Merge a pull request safely with all required checks. Use when the user says "merge", "merge the PR", "let's merge", "ship it", or asks to complete/land a pull request. Enforces CI pass, comment resolution, and squash merge.
+---
+
+# Merge Pull Request
+
+Safely merge a PR with all mandatory checks. Never skip steps.
+
+## Procedure
+
+### Step 1: Identify the PR
+
+```bash
+gh pr list --state open
+```
+
+If multiple PRs are open, ask the user which one to merge.
+If on a feature branch, use the PR for the current branch:
+
+```bash
+gh pr list --head "$(git branch --show-current)"
+```
+
+### Step 2: Check CI status
+
+```bash
+gh pr checks <PR_NUMBER>
+```
+
+- **All checks must pass.** If any check is `pending`, wait and re-check (sleep 15–30s between attempts, up to 5 minutes).
+- If a check **fails**, stop. Report the failure to the user. Do NOT merge.
+
+### Step 3: Check PR comments
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments
+```
+
+Also check review comments:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/reviews
+```
+
+- If there are **unresolved comments or change requests**, stop. Show the comments to the user and address them. After fixing, push changes and go back to Step 2.
+- If there are **no comments** or all are resolved/approved, proceed.
+
+### Step 4: Squash merge
+
+**ALWAYS use squash merge. Never regular merge or rebase.**
+
+```bash
+gh pr merge <PR_NUMBER> --squash
+```
+
+### Step 5: Update local main
+
+```bash
+git checkout main && git pull
+```
+
+### Step 6: Confirm
+
+Report to the user:
+- PR number and title
+- Merge status (success)
+- Any post-merge actions (e.g., deploy triggered)
+
+## Rules
+
+- **Never push directly to main.** All changes go through PRs.
+- **Never merge with failing CI.** Wait or fix first.
+- **Never merge with unaddressed comments.** Resolve everything.
+- **Always squash merge.** Clean history, one commit per feature.
+- **Never skip steps.** Even if the user says "just merge it", run all checks first and inform them of any issues.


### PR DESCRIPTION
## Summary

- **New `merge-pr` skill** (`.cursor/skills/merge-pr/SKILL.md`) — a project-level Cursor skill that provides the full step-by-step merge procedure. The agent auto-detects it when the user says "merge the PR", "let's merge", "ship it", etc.
- **Updated `workflow.md` rule** to reference the skill for detailed procedure, keeping core merge rules inline as quick reference

## Why a skill (not a rule or command)?

- **Not a rule** — rules are passive behavioral guidance loaded into every conversation. The merge procedure is a multi-step workflow that should only load when relevant.
- **Not a command** — commands are user-triggered only. The agent should auto-detect when a merge is requested.
- **A skill** — loads on demand, auto-detected by the agent, supports the procedural multi-step workflow with decision logic (wait for CI, address comments).

## Test plan
- [ ] Existing tests pass
- [ ] Agent recognizes merge-related requests and follows the skill procedure
- [ ] Skill enforces: CI pass, comment resolution, squash merge, update main


Made with [Cursor](https://cursor.com)