### PR TITLE
docs: require explicit user confirmation before merging PRs

### DIFF
--- a/.cursor/rules/workflow.md
+++ b/.cursor/rules/workflow.md
@@ -46,11 +46,12 @@ test/*       — test additions (test/markdown-export)
 **For the full step-by-step merge procedure, use the `merge-pr` skill (`.cursor/skills/merge-pr/SKILL.md`).**
 
 Core rules (non-negotiable):
-1. **CI must pass** — do NOT merge if any check is failing or pending.
-2. **All PR comments must be addressed** — resolve every comment before merging.
-3. **ALWAYS squash merge** — `gh pr merge N --squash`. Never regular merge or rebase. Squash keeps `main` history clean with one commit per feature/fix.
-4. After merge, the deploy workflow auto-triggers for `main` pushes.
-5. Pull latest main after merging: `git checkout main && git pull`
+1. **Always ask before merging** — never merge automatically. Report CI/comment status, then ask the user for explicit confirmation. The user may have additional instructions.
+2. **CI must pass** — do NOT merge if any check is failing or pending.
+3. **All PR comments must be addressed** — resolve every comment before merging.
+4. **ALWAYS squash merge** — `gh pr merge N --squash`. Never regular merge or rebase. Squash keeps `main` history clean with one commit per feature/fix.
+5. After merge, the deploy workflow auto-triggers for `main` pushes.
+6. Pull latest main after merging: `git checkout main && git pull`
 
 ## CI Pipeline
 

--- a/.cursor/skills/merge-pr/SKILL.md
+++ b/.cursor/skills/merge-pr/SKILL.md
@@ -7,7 +7,17 @@ description: Merge a pull request safely with all required checks. Use when the 
 
 Safely merge a PR with all mandatory checks. Never skip steps.
 
+**CRITICAL: Never merge automatically.** After completing all checks (CI, comments), always stop and ask the user for explicit confirmation before merging. The user may have additional instructions, want to review something first, or need to coordinate timing.
+
 ## Procedure
+
+### Step 0: Ask for confirmation
+
+After creating a PR or when the user mentions merging, **always ask the user first**:
+- Report: CI status, comment status, PR summary
+- Then ask: "Ready to merge?" or "Shall I squash merge this?"
+- **Wait for explicit "yes" / confirmation before proceeding to the merge step.**
+- Do NOT merge just because all checks pass. The user decides when.
 
 ### Step 1: Identify the PR
 
@@ -69,6 +79,7 @@ Report to the user:
 
 ## Rules
 
+- **Always ask before merging.** Never merge without explicit user confirmation. Report status, then wait for a "yes".
 - **Never push directly to main.** All changes go through PRs.
 - **Never merge with failing CI.** Wait or fix first.
 - **Never merge with unaddressed comments.** Resolve everything.


### PR DESCRIPTION
## Summary

- Add "always ask before merging" as the **first and most important rule** in both the `merge-pr` skill and `workflow.md` rules
- After all checks pass (CI, comments), the agent must report status and **wait for explicit user confirmation** before executing the merge
- Prevents the agent from auto-merging PRs — the user may have additional instructions, want to review, or need to coordinate timing

## Test plan
- [ ] Existing tests pass
- [ ] Agent asks for confirmation before merging instead of merging immediately


Made with [Cursor](https://cursor.com)