### PR TITLE
fix: incremental sync, configurable batch size, local-first message list

### DIFF
--- a/src/lib/gmail-api.js
+++ b/src/lib/gmail-api.js
@@ -78,7 +78,9 @@ export function listHistory(
   const params = new URLSearchParams();
   params.set("startHistoryId", startHistoryId);
   params.set("maxResults", String(maxResults));
-  params.set("historyTypes", "messageAdded,messageDeleted");
+  // Gmail API requires historyTypes as repeated params, not comma-separated
+  params.append("historyTypes", "messageAdded");
+  params.append("historyTypes", "messageDeleted");
   if (pageToken) params.set("pageToken", pageToken);
   return api(token, `/history?${params}`);
 }


### PR DESCRIPTION
## Summary

- **Fix broken incremental sync** — Gmail History API requires `historyTypes` as repeated query params (`historyTypes=messageAdded&historyTypes=messageDeleted`), not comma-separated. This caused the "Invalid value at history_types" error on second sync.
- **Configurable sync limits** — Default 50 messages per batch (was hardcoded 500). Dropdown selector for 50/100/200/500/All. New "Sync More" button continues downloading older messages, tracking resume point in syncState.
- **Local-first message list** — Removed "Fetch Messages" (direct Gmail API calls). Messages now load from IndexedDB immediately. Search bar queries local store (subject, sender, snippet). No more redundant API fetching.

## Changes
- `src/lib/gmail-api.js` — Fix `listHistory` params (`.append()` instead of `.set()`)
- `src/lib/store/gmail-sync.js` — Add `syncGmailMore()`, configurable `limit`, track `oldestPageToken`/`hasMore`
- `src/lib/store/query-layer.js` — Add `getStoredEmails()` for UI (raw objects, not LLM-formatted)
- `src/components/dashboard/SyncStatus.svelte` — Batch size selector, "Sync New" + "Sync More" buttons
- `src/components/dashboard/DashboardView.svelte` — Local search, local pagination, no API fetch
- `src/Dashboard.svelte` — Remove `fetchMessages`, add `loadLocalMessages`/`searchLocal`/`startSyncMore`

## Test plan
- [ ] Existing tests pass (32/32)
- [ ] Build succeeds
- [ ] First sync downloads 50 emails (configurable via dropdown)
- [ ] "Sync More" downloads the next batch of older emails
- [ ] "Sync New" (incremental) works without error
- [ ] Search bar filters locally stored emails
- [ ] "Load More" paginates through local results
- [ ] Clear data wipes store and resets UI
- [ ] Changing batch size to "All" downloads everything


Made with [Cursor](https://cursor.com)