### PR TITLE
chore: add PR preview deploys to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,16 +6,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
-  group: pages
+  group: pages-deploy
   cancel-in-progress: true
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,16 +26,9 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: peaceiris/actions-gh-pages@v4
         with:
-          path: dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          # Keep pr-preview/ subdirectories intact when deploying production
+          keep_files: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,33 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install and Build
+        if: github.event.action != 'closed'
+        run: |
+          npm ci
+          npm run build
+        env:
+          VITE_BASE: "./"
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./dist/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,8 @@ import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 
 export default defineConfig({
-  base: process.env.GITHUB_ACTIONS ? "/me-ai/" : "/",
+  // VITE_BASE overrides the base path (used by PR preview deploys).
+  // Fallback: "/me-ai/" in CI, "/" locally.
+  base: process.env.VITE_BASE || (process.env.GITHUB_ACTIONS ? "/me-ai/" : "/"),
   plugins: [svelte()],
 });


### PR DESCRIPTION
## Summary

- **PR preview deploys** — every PR automatically gets a live preview at \`https://cypherkitty.github.io/me-ai/pr-preview/pr-N/\`. Bot comments the link on the PR. Preview cleaned up when PR closes.
- **Pages source switched** from "GitHub Actions" to "Deploy from branch" (gh-pages) to support both production and preview deployments on the same branch
- **deploy.yml rewritten** to use \`peaceiris/actions-gh-pages\` (pushes to gh-pages root, preserves pr-preview/ dirs)
- **preview.yml added** using \`rossjrw/pr-preview-action@v1\` (builds with relative base path, deploys to subdirectory)
- **vite.config.js** now supports \`VITE_BASE\` env var override for flexible base path

## How it works

\`\`\`
gh-pages branch:
  /                     ← production (from main)
  /pr-preview/pr-20/    ← PR #20 preview
  /pr-preview/pr-21/    ← PR #21 preview
\`\`\`

## Note

OAuth won't work on preview URLs (redirect URIs not configured for them). Previews are for verifying UI/build, not full auth flow.

## Test plan
- [ ] Existing tests pass (32/32)
- [ ] Build succeeds
- [ ] This PR itself should trigger a preview deploy (check for bot comment with link)
- [ ] After merge, production deploy still works at https://cypherkitty.github.io/me-ai/


Made with [Cursor](https://cursor.com)