### PR TITLE
feat: show pending action items notification in chat

### DIFF
--- a/src/components/chat/ChatView.svelte
+++ b/src/components/chat/ChatView.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from "svelte";
   import MessageBubble from "./MessageBubble.svelte";
+  import PendingActionsCard from "./PendingActionsCard.svelte";
   import GpuPanel from "./GpuPanel.svelte";
   import { mountLog } from "../../lib/debug.js";
 
@@ -8,6 +9,7 @@
 
   let {
     messages = [],
+    pendingActions = null,
     isRunning = false,
     tps = null,
     numTokens = null,
@@ -65,7 +67,9 @@
   {/if}
 
   <div class="messages" bind:this={chatContainer}>
-    {#if messages.length === 0}
+    {#if pendingActions && messages.length === 0}
+      <PendingActionsCard pendingData={pendingActions} {onsend} />
+    {:else if messages.length === 0}
       <div class="empty">Send a message to start chatting.</div>
     {/if}
 

--- a/src/components/chat/PendingActionsCard.svelte
+++ b/src/components/chat/PendingActionsCard.svelte
@@ -1,0 +1,325 @@
+<script>
+  import { actionColor } from "../../lib/triage.js";
+
+  let {
+    pendingData,
+    onsend,
+  } = $props();
+
+  let customAction = $state("");
+  let expandedGroup = $state(null);
+
+  function formatAction(action) {
+    return action.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+
+  function handleQuickAction(text) {
+    onsend(text);
+  }
+
+  function handleCustomSubmit() {
+    const text = customAction.trim();
+    if (!text) return;
+    onsend(text);
+    customAction = "";
+  }
+
+  function handleKeydown(e) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleCustomSubmit();
+    }
+  }
+
+  function toggleGroup(action) {
+    expandedGroup = expandedGroup === action ? null : action;
+  }
+</script>
+
+<div class="pending-card">
+  <div class="card-header">
+    <span class="icon">&#128276;</span>
+    <div>
+      <h3>You have {pendingData.total} pending action{pendingData.total !== 1 ? "s" : ""}</h3>
+      <p class="subtitle">Here's what needs your attention:</p>
+    </div>
+  </div>
+
+  <div class="groups">
+    {#each pendingData.order as action (action)}
+      {@const items = pendingData.groups[action]}
+      {@const color = actionColor(action)}
+      <div class="group">
+        <button class="group-header" onclick={() => toggleGroup(action)}>
+          <span class="action-badge" style="background: {color}20; color: {color}; border-color: {color}40">
+            {formatAction(action)}
+          </span>
+          <span class="count">{items.length}</span>
+          <span class="chevron" class:expanded={expandedGroup === action}>&#9654;</span>
+        </button>
+
+        {#if expandedGroup === action}
+          <div class="group-items">
+            {#each items.slice(0, 5) as item (item.emailId)}
+              <div class="item">
+                <div class="item-subject">{item.subject}</div>
+                <div class="item-meta">
+                  {item.from}
+                  {#if item.date}
+                    &middot; {new Date(item.date).toLocaleDateString()}
+                  {/if}
+                </div>
+                {#if item.summary}
+                  <div class="item-summary">{item.summary}</div>
+                {/if}
+              </div>
+            {/each}
+            {#if items.length > 5}
+              <div class="more">...and {items.length - 5} more</div>
+            {/if}
+          </div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+
+  <div class="suggestions">
+    <p class="suggestions-label">Quick actions:</p>
+    <div class="chips">
+      <button class="chip" onclick={() => handleQuickAction("Summarize all my pending action items and help me prioritize them")}>
+        Prioritize all
+      </button>
+      <button class="chip" onclick={() => handleQuickAction("Which pending emails can I safely archive or delete?")}>
+        What to archive?
+      </button>
+      <button class="chip" onclick={() => handleQuickAction("Which pending emails need an urgent reply?")}>
+        Urgent replies?
+      </button>
+      <button class="chip" onclick={() => handleQuickAction("Help me write replies for pending emails that need a response")}>
+        Draft replies
+      </button>
+    </div>
+  </div>
+
+  <div class="custom-action">
+    <p class="custom-label">Or describe what you'd like to do:</p>
+    <div class="custom-input-row">
+      <textarea
+        rows="1"
+        placeholder="e.g. 'Mark all newsletters as read' or 'What deliveries am I waiting for?'"
+        bind:value={customAction}
+        onkeydown={handleKeydown}
+      ></textarea>
+      <button
+        class="send-btn"
+        onclick={handleCustomSubmit}
+        disabled={!customAction.trim()}
+      >Go</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .pending-card {
+    background: linear-gradient(135deg, #1a2332 0%, #1e1e2e 100%);
+    border: 1px solid #2a3a4a;
+    border-radius: 12px;
+    padding: 1rem 1.2rem;
+    max-width: 90%;
+    align-self: flex-start;
+  }
+
+  .card-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+  .icon {
+    font-size: 1.4rem;
+    line-height: 1;
+    flex-shrink: 0;
+    margin-top: 0.1rem;
+  }
+  .card-header h3 {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #e8e8e8;
+  }
+  .subtitle {
+    margin: 0.15rem 0 0;
+    font-size: 0.8rem;
+    color: #888;
+  }
+
+  /* ── Groups ──────────────────────────────────────────────────────── */
+  .groups {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-bottom: 0.75rem;
+  }
+  .group-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.4rem 0.5rem;
+    border: none;
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.15s;
+    text-align: left;
+    color: inherit;
+    font-family: inherit;
+  }
+  .group-header:hover {
+    background: rgba(255, 255, 255, 0.06);
+  }
+  .action-badge {
+    font-size: 0.72rem;
+    font-weight: 600;
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+    border: 1px solid;
+    white-space: nowrap;
+  }
+  .count {
+    font-size: 0.75rem;
+    color: #888;
+    font-variant-numeric: tabular-nums;
+  }
+  .chevron {
+    margin-left: auto;
+    font-size: 0.6rem;
+    color: #666;
+    transition: transform 0.15s;
+  }
+  .chevron.expanded {
+    transform: rotate(90deg);
+  }
+
+  /* ── Group items ─────────────────────────────────────────────────── */
+  .group-items {
+    padding: 0.25rem 0 0.25rem 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .item {
+    padding: 0.35rem 0.5rem;
+    background: rgba(255, 255, 255, 0.02);
+    border-radius: 4px;
+    border-left: 2px solid #333;
+  }
+  .item-subject {
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: #ddd;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .item-meta {
+    font-size: 0.7rem;
+    color: #777;
+    margin-top: 0.1rem;
+  }
+  .item-summary {
+    font-size: 0.72rem;
+    color: #999;
+    margin-top: 0.2rem;
+    line-height: 1.4;
+  }
+  .more {
+    font-size: 0.72rem;
+    color: #666;
+    font-style: italic;
+    padding-left: 0.5rem;
+  }
+
+  /* ── Quick action chips ──────────────────────────────────────────── */
+  .suggestions {
+    margin-bottom: 0.75rem;
+  }
+  .suggestions-label {
+    font-size: 0.75rem;
+    color: #888;
+    margin: 0 0 0.4rem;
+    font-weight: 500;
+  }
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+  .chip {
+    font-size: 0.75rem;
+    padding: 0.3rem 0.65rem;
+    border: 1px solid #3b82f6;
+    border-radius: 16px;
+    background: rgba(59, 130, 246, 0.08);
+    color: #6aa3f8;
+    cursor: pointer;
+    transition: all 0.15s;
+    font-family: inherit;
+    white-space: nowrap;
+  }
+  .chip:hover {
+    background: rgba(59, 130, 246, 0.18);
+    color: #93bbfc;
+  }
+
+  /* ── Custom action input ─────────────────────────────────────────── */
+  .custom-action {
+    border-top: 1px solid #2a3a4a;
+    padding-top: 0.65rem;
+  }
+  .custom-label {
+    font-size: 0.75rem;
+    color: #888;
+    margin: 0 0 0.35rem;
+    font-weight: 500;
+  }
+  .custom-input-row {
+    display: flex;
+    gap: 0.4rem;
+  }
+  .custom-input-row textarea {
+    flex: 1;
+    resize: none;
+    border: 1px solid #333;
+    border-radius: 8px;
+    background: #1a1a1a;
+    color: #e8e8e8;
+    padding: 0.45rem 0.65rem;
+    font-size: 0.82rem;
+    font-family: inherit;
+    line-height: 1.4;
+    outline: none;
+  }
+  .custom-input-row textarea:focus {
+    border-color: #3b82f6;
+  }
+  .send-btn {
+    padding: 0.45rem 0.9rem;
+    border: 1px solid #3b82f6;
+    border-radius: 8px;
+    background: #3b82f6;
+    color: #fff;
+    font-size: 0.82rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s;
+    font-family: inherit;
+  }
+  .send-btn:hover:not(:disabled) {
+    background: #2563eb;
+  }
+  .send-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+</style>

--- a/src/lib/store/query-layer.js
+++ b/src/lib/store/query-layer.js
@@ -227,6 +227,82 @@ export async function getContacts(limit = 50) {
     .join("\n");
 }
 
+// ── Pending actions for chat ─────────────────────────────────────────
+
+/**
+ * Get pending email classifications grouped by action type.
+ * Returns null if there are no pending items.
+ *
+ * @returns {Promise<{groups: Object, order: string[], total: number}|null>}
+ */
+export async function getPendingActions() {
+  const all = await db.emailClassifications
+    .where("status")
+    .equals("pending")
+    .toArray();
+
+  if (all.length === 0) return null;
+
+  const groups = {};
+  for (const item of all) {
+    const key = item.action || "UNKNOWN";
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(item);
+  }
+
+  // Sort each group by date descending
+  for (const key of Object.keys(groups)) {
+    groups[key].sort((a, b) => (b.date || 0) - (a.date || 0));
+  }
+
+  // Group order: largest groups first
+  const order = Object.keys(groups).sort(
+    (a, b) => groups[b].length - groups[a].length
+  );
+
+  return { groups, order, total: all.length };
+}
+
+/**
+ * Build an LLM context string that includes pending action items.
+ * This gives the LLM full awareness of what needs the user's attention.
+ *
+ * @returns {Promise<string|null>}
+ */
+export async function buildPendingActionsContext() {
+  const pending = await getPendingActions();
+  if (!pending) return null;
+
+  const parts = [
+    "## Pending Action Items",
+    `You have ${pending.total} pending email action items that need attention:`,
+    "",
+  ];
+
+  for (const action of pending.order) {
+    const items = pending.groups[action];
+    const label = action.replace(/_/g, " ");
+    parts.push(`### ${label} (${items.length})`);
+    for (const item of items.slice(0, 5)) {
+      const date = item.date
+        ? new Date(item.date).toLocaleDateString()
+        : "unknown date";
+      parts.push(`- **${item.subject}** from ${item.from} (${date})`);
+      if (item.summary) parts.push(`  ${item.summary}`);
+    }
+    if (items.length > 5) {
+      parts.push(`  ...and ${items.length - 5} more`);
+    }
+    parts.push("");
+  }
+
+  parts.push(
+    "The user is seeing these pending items in their chat. Help them decide what to do with these items. You can suggest specific actions like archiving, replying, following up, etc."
+  );
+
+  return parts.join("\n");
+}
+
 // ── LLM context building ────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

- When the Chat page loads with a model ready, pending email classifications are automatically fetched from IndexedDB and displayed as an interactive notification card
- The card shows action groups (e.g., REPLY, TRACK_DELIVERY) with counts, expandable email details, quick action chips ("Prioritize all", "What to archive?", "Urgent replies?", "Draft replies"), and a free-form text input for custom instructions
- Pending actions context is injected into the LLM system prompt when the user sends a message, so the model can reason about their action items and provide relevant suggestions

## Test plan

- [ ] Verify chat page loads normally when no pending actions exist (shows "Send a message to start chatting")
- [ ] Classify some emails on the Actions page, then switch to Chat — pending actions card should appear
- [ ] Click on action group headers to expand/collapse item details
- [ ] Click quick action chips — they should send the pre-filled message to the LLM
- [ ] Type a custom action in the free-form input and press Enter or click "Go"
- [ ] Verify the LLM receives pending actions context and can reason about them
- [ ] After sending a message, the notification card is replaced by the conversation
- [ ] All 66 unit tests and 11 E2E tests pass


Made with [Cursor](https://cursor.com)