### PR TITLE
fix: stop loading all emails into LLM context on every chat message

### DIFF
--- a/src/lib/llm-context.js
+++ b/src/lib/llm-context.js
@@ -11,7 +11,6 @@ import {
   getDetailedSummary,
   getRecentEmails,
   searchData,
-  getPendingActions,
 } from "./store/query-layer.js";
 
 // ── LLM context building ────────────────────────────────────────────
@@ -56,43 +55,4 @@ export async function buildEmailContext(userQuery) {
   return parts.join("\n");
 }
 
-/**
- * Build an LLM context string that includes pending action items.
- * This gives the LLM full awareness of what needs the user's attention.
- *
- * @returns {Promise<string|null>}
- */
-export async function buildPendingActionsContext() {
-  const pending = await getPendingActions();
-  if (!pending) return null;
-
-  const parts = [
-    "## Pending Action Items",
-    `You have ${pending.total} pending email action items that need attention:`,
-    "",
-  ];
-
-  for (const action of pending.order) {
-    const items = pending.groups[action];
-    const label = action.replace(/_/g, " ");
-    parts.push(`### ${label} (${items.length})`);
-    for (const item of items.slice(0, 5)) {
-      const date = item.date
-        ? new Date(item.date).toLocaleDateString()
-        : "unknown date";
-      parts.push(`- **${item.subject}** from ${item.from} (${date})`);
-      if (item.summary) parts.push(`  ${item.summary}`);
-    }
-    if (items.length > 5) {
-      parts.push(`  ...and ${items.length - 5} more`);
-    }
-    parts.push("");
-  }
-
-  parts.push(
-    "The user is seeing these pending items in their chat. Help them decide what to do with these items. You can suggest specific actions like archiving, replying, following up, etc."
-  );
-
-  return parts.join("\n");
-}
 


### PR DESCRIPTION
## Summary

- **Remove `buildPendingActionsContext()`** — it queried all pending classifications on every send() and injected them into the system prompt. The ActionDashboard already shows this visually; the LLM doesn't need it.
- **Only load email context when user asks about emails** — removed `|| pendingCtx` condition so `buildEmailContext()` only runs when the message matches email keywords.
- **Make `getDataSummary()` and `getDetailedSummary()` lightweight** — removed full `toArray()` table scans for top senders and label distribution. Both now use only indexed `count()` and compound-index range queries.
- **Net result**: -117 lines, zero full table scans on normal chat messages, drastically smaller system prompts, faster GPU inference.

## Test plan

- [x] `npm run build` passes
- [x] All 66 unit tests pass (`npx vitest run`)
- [ ] Manual: send a general question (e.g. "what is 2+2") — should respond fast, no long "preparing..." phase
- [ ] Manual: send an email question (e.g. "show my recent emails") — should still load email context correctly
- [ ] Manual: verify tok/s stats display in header during and after generation


Made with [Cursor](https://cursor.com)