### PR TITLE
fix: pass full email body to LLM for classification

### DIFF
--- a/src/components/actions/PromptInspector.svelte
+++ b/src/components/actions/PromptInspector.svelte
@@ -62,7 +62,7 @@
         {:else if activeTab === "email"}
           <div class="section-desc">
             Each email is formatted into this template and sent as the user message.
-            The body is truncated to 500 characters.
+            The full email body is included.
           </div>
           <div class="template-format">
             <div class="format-label">Format:</div>
@@ -72,7 +72,7 @@ To: {"{email.to}"}
 Date: {"{formatted date}"}
 Labels: {"{email.labels}"}
 
-{"{email.body, truncated to 500 chars}"}</pre>
+{"{email.body (full content)"}</pre>
           </div>
           <div class="template-format">
             <div class="format-label">Sample:</div>

--- a/src/lib/triage.js
+++ b/src/lib/triage.js
@@ -8,7 +8,7 @@
 
 import { db } from "./store/db.js";
 import Dexie from "dexie";
-import { truncate, stringToHue } from "./format.js";
+import { stringToHue } from "./format.js";
 import { groupByAction } from "./email-utils.js";
 
 const DEFAULT_COUNT = 20;
@@ -278,7 +278,7 @@ export function formatEmailPrompt(email) {
         weekday: "short", year: "numeric", month: "short", day: "numeric",
       })
     : "Unknown date";
-  const body = truncate(email.body || email.snippet || "", 500);
+  const body = email.body || email.snippet || "";
 
   return [
     `Subject: ${email.subject}`,


### PR DESCRIPTION
## Summary

- Remove the 500-character truncation from `formatEmailPrompt()` — the full email body is now sent to the LLM
- Clean up unused `truncate` import from `triage.js`
- Update Prompt Inspector text to reflect the change

## Why

The LLM was classifying emails based on only the first 500 characters. For longer emails, key content like payment amounts, deadlines, tracking numbers, or action items buried deeper in the body was invisible to the model, leading to poor classification.

## Test plan

- [x] Build passes
- [x] All 74 tests pass
- [ ] Manual: classify a long email — model should now see full content


Made with [Cursor](https://cursor.com)