### PR TITLE
fix: show 100% completion instead of 0% when scan finishes

### DIFF
--- a/src/lib/triage.js
+++ b/src/lib/triage.js
@@ -216,6 +216,8 @@ export async function scanEmails(
   const totalElapsed = performance.now() - scanStart;
   onProgress({
     phase: "done",
+    current: toProcess.length,
+    total: toProcess.length,
     classified,
     errors,
     totals: { outputTokens: totalOutputTokens, inputTokens: totalInputTokens, elapsed: totalElapsed },


### PR DESCRIPTION
## Summary

- The scan completion screen showed "Scan complete" but "0%" instead of "100%"
- Root cause: the `done` phase progress event was missing `current` and `total` fields
- The percentage calculation `progress.current / progress.total` returned `0 / undefined = 0`

## Fix

Emit `current` and `total` (both set to `toProcess.length`) in the final "done" progress event so the percentage correctly shows 100%.

## Test plan

- [x] `npx vite build` — clean build
- [x] `npx vitest run` — all 74 tests pass
- [ ] Manual: run a scan, verify completion shows "100%" instead of "0%"


Made with [Cursor](https://cursor.com)