### PR TITLE
feat: add GPT-OSS 20B to WebGPU model list

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -71,6 +71,17 @@ export const MODELS = [
     maxEmailTokens: 2000, // Small model, limited WebGPU memory
     description: "Smallest, ultra fast, 8k context, not for long emails"
   },
+  {
+    id: "onnx-community/gpt-oss-20b-ONNX",
+    name: "GPT-OSS 20B",
+    size: "~12 GB",
+    contextWindow: 131072, // 128k
+    maxEmailTokens: 16000,
+    description: "OpenAI open-source 20B, 128k context, built-in reasoning",
+    requiresV4: true,
+    gpuWarning: "Requires powerful GPU (12GB+ VRAM). ~12 GB download.",
+    isExperimental: true
+  },
 ];
 
 /**


### PR DESCRIPTION
## Summary

- Adds `onnx-community/gpt-oss-20b-ONNX` to the WebGPU model list in `src/lib/models.js`
- OpenAI's open-source 20B model, Apache-2.0 license
- Runs fully in-browser via WebGPU using `q4f16` quantization (same dtype as all other models)
- 128k context window, ~12 GB download
- Flagged as `requiresV4: true`, `isExperimental: true`, with GPU warning (12GB+ VRAM)
- No other code changes needed — model ID starts with `onnx-community/` so `unified-engine.js` already routes it to WebGPU automatically

## Reference

- HuggingFace Space: https://huggingface.co/spaces/webml-community/GPT-OSS-WebGPU
- ONNX model: https://huggingface.co/onnx-community/gpt-oss-20b-ONNX
- Base model: https://huggingface.co/openai/gpt-oss-20b

## Test plan

- [ ] Select GPT-OSS 20B from the model picker (requires good GPU)
- [ ] Model downloads and loads via WebGPU
- [ ] Chat works and responses stream correctly

Made with [Cursor](https://cursor.com)