### PR TITLE
feat: show model name in each chat message

### DIFF
--- a/src/Chat.svelte
+++ b/src/Chat.svelte
@@ -98,7 +98,7 @@
         case "start":
           if (!isRunning) break;
           generationPhase = msg.phase || "preparing";
-          messages = [...messages, { role: "assistant", content: "", thinking: "" }];
+          messages = [...messages, { role: "assistant", content: "", thinking: "", model: selectedModel }];
           break;
 
         case "phase":

--- a/src/components/chat/MessageBubble.svelte
+++ b/src/components/chat/MessageBubble.svelte
@@ -3,6 +3,7 @@
   import DOMPurify from "dompurify";
   import { onMount } from "svelte";
   import { mountLog } from "../../lib/debug.js";
+  import { getModelInfo } from "../../lib/models.js";
 
   let {
     msg,
@@ -36,6 +37,18 @@
   let modelLabel = $derived(backend ? (BACKEND_LABELS[backend] ?? backend) : "AI");
   let modelColor = $derived(backend ? (BACKEND_COLORS[backend] ?? "#888") : "#888");
 
+  let modelName = $derived.by(() => {
+    if (!msg.model) return null;
+    const info = getModelInfo(msg.model);
+    if (info) return info.name;
+    // fallback: strip namespace and common ONNX suffixes, humanise
+    return msg.model
+      .split("/").pop()
+      .replace(/[-_](ONNX|onnx)([-_](GQA|MHA|web|DQ))*$/i, "")
+      .replace(/[-_]/g, " ")
+      .trim();
+  });
+
   let html = $derived.by(() => {
     if (msg.role !== "assistant" || !msg.content) return "";
     try {
@@ -60,6 +73,10 @@
       <span class="ai-badge" style:color={modelColor} style:border-color={"color-mix(in srgb," + modelColor + " 30%, transparent)"} style:background={"color-mix(in srgb," + modelColor + " 8%, transparent)"}>
         {modelLabel}
       </span>
+
+      {#if modelName}
+        <span class="model-name">{modelName}</span>
+      {/if}
 
       {#if isStreaming && generationPhase === "thinking"}
         <span class="phase-tag thinking">
@@ -157,6 +174,13 @@
     border-radius: 4px;
     border: 1px solid;
     flex-shrink: 0;
+  }
+
+  .model-name {
+    font-size: 0.7rem;
+    color: #4a4a4a;
+    font-weight: 400;
+    letter-spacing: 0;
   }
 
   /* phase tags */


### PR DESCRIPTION
## Summary

- Stamps `model: selectedModel` onto each assistant message in `Chat.svelte` when it is created
- `MessageBubble.svelte` now resolves `msg.model` to a friendly name:
  - Uses `getModelInfo()` for known WebGPU models (returns e.g. `Qwen3 0.6B`)
  - Falls back to parsing the model ID for unknown/cloud models (strips namespace + ONNX suffixes)
- Renders the model name as small dim text right after the `WEBGPU` / `Claude` / `OpenAI` etc. badge
- Each message independently tracks which model generated it (survives backend switches mid-conversation)

## Test plan

- [ ] Send a message with a WebGPU model selected → badge shows e.g. `WEBGPU · Qwen3 0.6B`
- [ ] Send a message with a cloud model → shows e.g. `OpenAI · gpt-4o`
- [ ] Old messages (no `msg.model`) show no model name — graceful fallback

Made with [Cursor](https://cursor.com)