### PR TITLE
feat: make GPT-OSS 20B the first and default model

### DIFF
--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -1,5 +1,17 @@
 /** Available ONNX models for browser inference with Transformers.js v4 */
 export const MODELS = [
+  {
+    id: "onnx-community/gpt-oss-20b-ONNX",
+    name: "GPT-OSS 20B",
+    size: "~12 GB",
+    contextWindow: 131072, // 128k
+    maxEmailTokens: 16000,
+    description: "OpenAI open-source 20B, 128k context, built-in reasoning",
+    requiresV4: true,
+    gpuWarning: "Requires powerful GPU (12GB+ VRAM). ~12 GB download.",
+    isExperimental: true,
+    recommendedForEmailProcessing: true
+  },
   { 
     id: "onnx-community/Qwen3-0.6B-ONNX", 
     name: "Qwen3 0.6B", 
@@ -70,17 +82,6 @@ export const MODELS = [
     contextWindow: 8192, // 8k
     maxEmailTokens: 2000, // Small model, limited WebGPU memory
     description: "Smallest, ultra fast, 8k context, not for long emails"
-  },
-  {
-    id: "onnx-community/gpt-oss-20b-ONNX",
-    name: "GPT-OSS 20B",
-    size: "~12 GB",
-    contextWindow: 131072, // 128k
-    maxEmailTokens: 16000,
-    description: "OpenAI open-source 20B, 128k context, built-in reasoning",
-    requiresV4: true,
-    gpuWarning: "Requires powerful GPU (12GB+ VRAM). ~12 GB download.",
-    isExperimental: true
   },
 ];
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -406,7 +406,7 @@ self.addEventListener("message", async (e) => {
       check();
       break;
     case "load":
-      load(modelId || "onnx-community/Qwen3-0.6B-ONNX");
+      load(modelId || "onnx-community/gpt-oss-20b-ONNX");
       break;
     case "generate":
       stopping_criteria.reset();


### PR DESCRIPTION
## Changes

- Move `GPT-OSS 20B` to position 0 in `MODELS` — `Chat.svelte` uses `MODELS[0].id` as the initial state, so this makes it the default without any extra code
- Add `recommendedForEmailProcessing: true` to GPT-OSS (128k context qualifies)
- Update the fallback model ID in `worker.js` to match

## Test plan

- [ ] Fresh load (no saved `selectedModel` in storage) defaults to GPT-OSS 20B
- [ ] Model selector shows GPT-OSS 20B at the top of the list
- [ ] Returning users with a saved model preference still get their saved choice

Made with [Cursor](https://cursor.com)