### PR TITLE
fix: Harmony split-token bug + model name shown only on change

### DIFF
--- a/src/components/chat/ChatView.svelte
+++ b/src/components/chat/ChatView.svelte
@@ -120,6 +120,7 @@
       {:else if msg.type === "event" || msg.type === "event-batch" || msg.type === "events-grouped"}
         <EventMessage {msg} {oncommand} {onexecuted} />
       {:else}
+        {@const prevModel = messages.slice(0, i).filter(m => m.role === "assistant").at(-1)?.model}
         <MessageBubble
           {msg}
           isLast={i === messages.length - 1}
@@ -127,6 +128,7 @@
           {generationPhase}
           {numTokens}
           {backend}
+          showModelName={msg.role === "assistant" && !!msg.model && msg.model !== prevModel}
         />
       {/if}
     {/each}

--- a/src/components/chat/MessageBubble.svelte
+++ b/src/components/chat/MessageBubble.svelte
@@ -12,6 +12,7 @@
     generationPhase = null,
     numTokens = null,
     backend = null,
+    showModelName = false,
   } = $props();
 
   onMount(() => mountLog(`MessageBubble[${msg.role}]`));
@@ -74,7 +75,7 @@
         {modelLabel}
       </span>
 
-      {#if modelName}
+      {#if showModelName && modelName}
         <span class="model-name">{modelName}</span>
       {/if}
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -64,11 +64,16 @@ function isHarmonyModel(model_id) {
  *   <|start|assistant<|channel|final<|message|[response]<|return|
  *
  * We buffer the stream and emit typed events as we detect boundaries.
+ *
+ * Key subtlety: special tokens like <|channel|> and <|message|> arrive
+ * in separate callback invocations, so we need a two-step "seenChannel"
+ * flag to pair them correctly across calls.
  */
 class HarmonyParser {
   constructor() {
     this.buf = "";
-    this.channel = null; // null | "analysis" | "final" | "skip"
+    this.channel = null;       // null | "analysis" | "final" | "skip"
+    this.seenChannel = false;  // consumed <|channel|>, waiting for <|message|>
     this.thinkBuffer = "";
   }
 
@@ -82,14 +87,21 @@ class HarmonyParser {
       changed = false;
 
       if (this.channel === null) {
-        const ci = this.buf.indexOf("<|channel|");
-        if (ci !== -1) {
-          // Drop everything before the channel marker (e.g. "<|start|assistant")
-          this.buf = this.buf.slice(ci + "<|channel|".length);
+        if (!this.seenChannel) {
+          const ci = this.buf.indexOf("<|channel|");
+          if (ci !== -1) {
+            // Drop everything before the channel marker (e.g. "<|start|assistant")
+            this.buf = this.buf.slice(ci + "<|channel|".length);
+            this.seenChannel = true;
+            changed = true;
+          }
+        } else {
+          // Already consumed <|channel|> — now wait for <|message|> to learn the name
           const mi = this.buf.indexOf("<|message|");
           if (mi !== -1) {
             const name = this.buf.slice(0, mi);
             this.buf = this.buf.slice(mi + "<|message|".length);
+            this.seenChannel = false;
             this.channel =
               name === "analysis" ? "analysis" :
               name === "final"    ? "final"    : "skip";
@@ -363,19 +375,17 @@ async function generate(messages, { maxTokens = 4096, enableThinking = true } = 
       if (harmony.channel === "final" && harmony.buf.trim()) {
         self.postMessage({ status: "update", output: harmony.buf.trim(), tps, numTokens });
       }
-      if (harmony.channel === "analysis" && harmony.thinkBuffer) {
-        self.postMessage({ status: "thinking-done", content: harmony.thinkBuffer, tps, numTokens });
+      if (harmony.channel === "analysis") {
+        const remaining = (harmony.thinkBuffer + harmony.buf).trim();
+        if (remaining) {
+          self.postMessage({ status: "thinking-done", content: remaining, tps, numTokens });
+        }
         self.postMessage({
           status: "update",
           output: "[Thinking used all tokens — no response generated. Try a shorter prompt.]",
           tps,
           numTokens,
         });
-      }
-      if (!harmonyContentStarted && !harmonyThinkingStarted) {
-        // Model produced no recognized output — show raw buffer as fallback
-        const raw = harmony.buf.replace(/<\|[^|]+\|>/g, "").trim();
-        if (raw) self.postMessage({ status: "update", output: raw, tps, numTokens });
       }
     }
 


### PR DESCRIPTION
## Changes

### `src/worker.js` — HarmonyParser split-token bug

**Root cause:** `<|channel|>` and `<|message|>` are separate tokens delivered in separate streaming callbacks. The parser consumed `<|channel|>` in one callback, sliced `buf` to `""`, then reset the while-loop — which immediately tried to find `<|channel|>` again (gone). Subsequent pushes of `"final"` and `"<|message|>"` were never paired, so the entire message fell into the end-of-generation fallback, producing `"finalHello! How can I help you today?"`.

**Fix:** Added a `seenChannel` boolean flag. After consuming `<|channel|>`, the loop switches to waiting specifically for `<|message|>` instead of searching for `<|channel|>` again. Also removed the noisy regex fallback that was the source of the visible leak.

### `src/components/chat/ChatView.svelte` + `MessageBubble.svelte` — model name once per model

Added a `showModelName` prop. `ChatView` computes it per message: `true` only when the current assistant message's `.model` differs from the previous assistant message's `.model`. The label appears on the first message of each model session and re-appears if the user switches models mid-conversation.

## Test plan

- [ ] GPT-OSS 20B: response shows clean text with no `final` prefix
- [ ] GPT-OSS 20B: reasoning appears in the thinking disclosure
- [ ] Model name "GPT-OSS 20B" appears only on the first assistant reply
- [ ] Switching models mid-chat: new model name appears on first reply with the new model
- [ ] Qwen3 / other models: unaffected

Made with [Cursor](https://cursor.com)