### PR TITLE
fix: Harmony hard fallback + skip enable_thinking for GPT-OSS

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -249,7 +249,8 @@ async function generate(messages, { maxTokens = 4096, enableThinking = true } = 
       add_generation_prompt: true,
       return_dict: true,
     };
-    if (!enableThinking) {
+    // enable_thinking is a Qwen3-specific option; skip for Harmony models
+    if (!enableThinking && !useHarmony) {
       templateOpts.enable_thinking = false;
     }
 
@@ -270,9 +271,11 @@ async function generate(messages, { maxTokens = 4096, enableThinking = true } = 
     let harmonyContentStarted = false;
     let harmonyThinkingStarted = false;
     let harmonyThinkingDone = false;
+    let harmonyRawBuffer = ""; // full raw stream, used as fallback
     const harmony = useHarmony ? new HarmonyParser() : null;
 
     const harmony_callback = (output) => {
+      harmonyRawBuffer += output;
       const events = harmony.push(output);
       for (const ev of events) {
         if (ev.t === "think-chunk") {
@@ -374,6 +377,7 @@ async function generate(messages, { maxTokens = 4096, enableThinking = true } = 
     if (useHarmony) {
       if (harmony.channel === "final" && harmony.buf.trim()) {
         self.postMessage({ status: "update", output: harmony.buf.trim(), tps, numTokens });
+        harmonyContentStarted = true;
       }
       if (harmony.channel === "analysis") {
         const remaining = (harmony.thinkBuffer + harmony.buf).trim();
@@ -386,6 +390,19 @@ async function generate(messages, { maxTokens = 4096, enableThinking = true } = 
           tps,
           numTokens,
         });
+        harmonyContentStarted = true;
+      }
+      // Hard fallback: parser produced nothing — strip all Harmony tokens and show raw text
+      if (!harmonyContentStarted) {
+        const stripped = harmonyRawBuffer
+          .replace(/<\|[^|]*\|>/g, "")   // remove <|token|> style tokens
+          .replace(/<\|[^|]*$/g, "")     // remove incomplete trailing token
+          .replace(/^(analysis|final|commentary|assistant|user|system)\b/g, "") // strip bare channel names at start
+          .trim();
+        if (stripped) {
+          self.postMessage({ status: "phase", phase: "generating" });
+          self.postMessage({ status: "update", output: stripped, tps, numTokens });
+        }
       }
     }
 


### PR DESCRIPTION
## Problem

GPT-OSS 20B responses were blank. The `WEBGPU | GPT-OSS 20B` header appeared (meaning `start` fired) but the content area stayed empty after generation completed.

Two root causes identified:

1. **Format mismatch / parser producing zero events** — if the actual token stream from GPT-OSS doesn't exactly match the expected `<|channel|name<|message|>` pattern (e.g. different whitespace, slightly different token boundaries), the `HarmonyParser` emits no `content` events and the response is silently dropped.

2. **`enable_thinking: false` passed to GPT-OSS** — this is a Qwen3-specific chat template option. Passing it to GPT-OSS's tokenizer may cause `apply_chat_template` to throw or produce a malformed prompt.

## Fix

**Hard fallback in `worker.js`:** Track the full raw stream in `harmonyRawBuffer`. After generation completes, if `harmonyContentStarted` is still `false`, strip all `<|token|>` markers and bare channel name prefixes from the raw buffer and emit whatever remains as a plain text response. This ensures the user always sees output regardless of format variations.

**Skip `enable_thinking` for Harmony models:** The `enable_thinking: false` template option is now only passed for non-Harmony models.

## Test plan

- [ ] GPT-OSS 20B: response is visible (via parser or fallback)
- [ ] GPT-OSS 20B: no blank message after generation completes
- [ ] Qwen3 / other models: unaffected

Made with [Cursor](https://cursor.com)