### PR TITLE
fix: remove preferredOutputLocation conflicting with enableGraphCapture

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -41,13 +41,13 @@ class TextGenerationPipeline {
       dtype: "q4f16",
       device: "webgpu",
       progress_callback,
-      // Keep all output tensors on the GPU buffer between decode steps —
-      // avoids GPU→CPU copies on every token, the biggest decode bottleneck.
+      // Graph capture: after the first decode step the WebGPU command
+      // sequence is recorded and replayed without CPU re-dispatch,
+      // recovering the utilisation drop seen during autoregressive decode.
+      // NOTE: enableGraphCapture requires ALL outputs to be on gpu-buffer;
+      // do NOT set preferredOutputLocation here — ONNX Runtime manages
+      // output locations automatically when graph capture is enabled.
       session_options: {
-        preferredOutputLocation: "gpu-buffer",
-        // Graph capture: after the first decode step the WebGPU command
-        // sequence is recorded and replayed without CPU re-dispatch,
-        // recovering the utilisation drop seen during autoregressive decode.
         enableGraphCapture: true,
       },
     });


### PR DESCRIPTION
## Error

```
Error: Not supported preferred output location: cpu.
Only 'gpu-buffer' location is supported when enableGraphCapture is true.
```

## Root cause

When `enableGraphCapture: true`, ONNX Runtime requires every session output to be on `gpu-buffer`. Setting `preferredOutputLocation: "gpu-buffer"` globally conflicts because some model outputs (e.g. logits that need to be read back on CPU for sampling) are registered as `cpu` outputs internally — causing the runtime to throw on load.

## Fix

Remove the explicit `preferredOutputLocation`. When `enableGraphCapture` is enabled, ONNX Runtime automatically manages output tensor locations to satisfy the graph capture constraint. No manual override needed.

Made with [Cursor](https://cursor.com)