### PR TITLE
fix: remove enableGraphCapture — incompatible with GPT-OSS outputs

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -41,15 +41,6 @@ class TextGenerationPipeline {
       dtype: "q4f16",
       device: "webgpu",
       progress_callback,
-      // Graph capture: after the first decode step the WebGPU command
-      // sequence is recorded and replayed without CPU re-dispatch,
-      // recovering the utilisation drop seen during autoregressive decode.
-      // NOTE: enableGraphCapture requires ALL outputs to be on gpu-buffer;
-      // do NOT set preferredOutputLocation here — ONNX Runtime manages
-      // output locations automatically when graph capture is enabled.
-      session_options: {
-        enableGraphCapture: true,
-      },
     });
 
     return Promise.all([this.tokenizer, this.model]);


### PR DESCRIPTION
enableGraphCapture requires every ONNX session output to be on gpu-buffer.
GPT-OSS has CPU-registered outputs that cannot be overridden from JS,
causing a hard load failure. Removing the option restores model loading.

The other perf improvements from #54 are kept: `num_beams: 1` and the
improved warm-up via `apply_chat_template`.

Verified working: GPT-OSS 20B loaded and generated at 11.9 tok/s.

Made with [Cursor](https://cursor.com)