### PR TITLE
fix(ci): VITE_BASE=/ for GitHub Pages custom domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,9 @@ jobs:
       - uses: arduino/setup-task@v2
 
       - run: task deploy-build
+        env:
+          # Custom domain is served at site root; /me-ai/ base would 404 assets (HTML vs /assets/).
+          VITE_BASE: /
 
       - uses: peaceiris/actions-gh-pages@v4
         with:

--- a/me-ai-web/e2e/app.spec.ts
+++ b/me-ai-web/e2e/app.spec.ts
@@ -165,7 +165,7 @@ test.describe("Pipeline sidebar", () => {
     await expect(page.getByRole("link", { name: /Pipelines/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /Approvals/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /Audit Trail/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Scan/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Scan", exact: true })).toBeVisible();
     await expect(page.getByRole("link", { name: /Settings/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /Back to Chat/i })).toBeVisible();
   });


### PR DESCRIPTION
Fixes blank site at https://www.me-and-my.ai/: HTML referenced `/me-ai/assets/*` while the custom domain is served at site root (404 on JS/CSS). Production deploy now sets `VITE_BASE=/`.

Made with [Cursor](https://cursor.com)