### PR TITLE
fix(ci): quote VITE_BASE for GitHub Actions YAML

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,8 @@ jobs:
       - run: task deploy-build
         env:
           # Custom domain is served at site root; /me-ai/ base would 404 assets (HTML vs /assets/).
-          VITE_BASE: /
+          # Quote "/" — YAML 1.2 can treat a bare `/` as regex, dropping the value.
+          VITE_BASE: "/"
 
       - uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
Follow-up to #84: production deploy still emitted `/me-ai/` asset paths because `VITE_BASE: /` may not bind as a string under YAML 1.2 (bare `/` treated as regex). Use `VITE_BASE: "/"` so Vite sees root base.

Made with [Cursor](https://cursor.com)