### PR TITLE
ci: Docker Buildx on GitHub Actions, GHA cache, Taskfile.ci/docker

### DIFF
--- a/.agents/me-ai-builder.md
+++ b/.agents/me-ai-builder.md
@@ -21,8 +21,19 @@ All build, test, and deploy steps use [Task](https://taskfile.dev) from the repo
 - `task test` — Run unit tests (Vitest, `npm run test:ci` in me-ai-web).
 - `task test:e2e` — Run E2E tests (Playwright); installs Chromium if needed.
 - `task check` — Run Svelte/TypeScript check in me-ai-web.
-- `task ci` — Full CI: install → unit tests → E2E tests. Same as GitHub Actions.
+- `task ci` — Alias for **`ci:full`** ([`Taskfile.ci.yml`](../Taskfile.ci.yml)): full **native** CI. GitHub Actions uses Docker + **`task ci:docker`** instead.
+- `task ci:full` — Same pipeline as `task ci` (explicit name in `Taskfile.ci.yml`).
+- `task ci:docker` — After `me-ai-core/pkg` exists (e.g. from `docker buildx bake ci` + copy from `pkg-docker/`): web install, cortex check, web checks, Vitest, Playwright — **no** `core:build` / `core:clippy` / `core:test` (those run in the Dockerfile on CI).
 - `task deploy-build` — Install then full build (for deploy/preview).
+
+**Docker** (requires Docker Buildx; tasks live in [`Taskfile.docker.yml`](../Taskfile.docker.yml), included as `docker:*`; see also [`docker-bake.hcl`](../docker-bake.hcl), [`Dockerfile`](../Dockerfile)):
+
+- `task docker:build` — Build and load `me-ai/web:latest` by default; override with `task docker:build REGISTRY=ghcr.io/org` (image is `REGISTRY/web:latest`).
+- `task docker:run` — `docker:build` then run the image (app on port 3000 → host 8080).
+- `task docker:push` — Push image tags (`PUSH_CACHE=1` enables registry cache write in bake).
+- `task docker:web-local` / `task docker:wasm-local` — Export `dist` / wasm `pkg` into `me-ai-web/dist-docker/` and `me-ai-core/pkg-docker/`.
+- `task docker:rust-test` — Run `cargo test --lib` for core inside a build stage.
+- `task docker:bake-ci` — `docker buildx bake ci` (web image, rust-test, wasm-clippy, wasm-local export). In CI, `CACHE_GHA=1` enables GitHub Actions cache.
 
 **Typical local workflow:**
 

--- a/.cortex/architecture.md
+++ b/.cortex/architecture.md
@@ -50,7 +50,9 @@ See [`.cortex/design-docs/plugin-system.md`](design-docs/plugin-system.md).
 
 All build/test/deploy goes through [Task](https://taskfile.dev). See `.agents/me-ai-builder.md`.
 
-Key tasks: `task install`, `task build`, `task test`, `task ci`, `task deploy-build`.
+Key tasks: `task install`, `task web:build`, `task web:test`, `task ci`, `task deploy-build`.
+
+**Docker (optional):** `task docker:build`, `task docker:run`, etc. — tasks live in [`Taskfile.docker.yml`](../Taskfile.docker.yml) (`docker:*` include). See [`.cortex/ci-cd.md`](ci-cd.md) § Docker builds and [namespaced task groups](references/taskfile-architecture.md#namespaced-task-groups).
 
 ## CI / CD
 

--- a/.cortex/ci-cd.md
+++ b/.cortex/ci-cd.md
@@ -1,27 +1,35 @@
 # CI / CD
 
-Four workflow files live under [`.github/workflows/`](../.github/workflows/). Most jobs delegate to the root [`Taskfile.yml`](../Taskfile.yml) after installing Node, Rust, wasm-pack, and Task.
+Four workflow files live under [`.github/workflows/`](../.github/workflows/). **CI on GitHub** builds Rust/WASM and runs core tests **in Docker** (Buildx + [`docker-bake.hcl`](../docker-bake.hcl) group `ci`), then runs **`task ci:docker`** for web install and JS checks. **Deploy / preview** still use `task deploy-build` (native wasm-pack + Vite on the runner).
 
 ## Reproduce GitHub CI locally
 
-The **CI** workflow’s only substantive step is `task ci` (see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)).
+**Same as GitHub Actions (Docker-backed):** from the repo root, with Docker Buildx and Task:
 
-From the **repository root**, with the same tooling CI expects:
+```bash
+CACHE_GHA=1 docker buildx bake ci
+mkdir -p me-ai-core/pkg && cp -a me-ai-core/pkg-docker/. me-ai-core/pkg/
+task ci:docker
+```
+
+(`CACHE_GHA=1` switches bake to `type=gha`-style cache entries; locally that is optional — omit it to use registry cache hints from [`docker-bake.hcl`](../docker-bake.hcl) or no remote cache.)
+
+**Full native pipeline (no Docker):** matches historical behaviour and is still useful locally:
 
 | Requirement | Notes |
 |---------------|--------|
-| [Task](https://taskfile.dev) v3 | `arduino/setup-task@v2` on CI |
-| Node **20** | CI uses `actions/setup-node@v4` with `node-version: 20` (match this locally to avoid engine warnings) |
-| Rust **stable** + `wasm32-unknown-unknown` | `dtolnay/rust-toolchain@stable` on CI |
-| **wasm-pack** | CI: `curl … wasm-pack/installer/init.sh`; deploy/preview: `jetli/wasm-pack-action@v0.4.0` |
-
-Run:
+| [Task](https://taskfile.dev) v3 | `arduino/setup-task@v2` on CI for `ci:docker` only; full `task ci` needs this |
+| Node **20** | `actions/setup-node@v4` with `node-version: 20` |
+| Rust **stable** + `wasm32-unknown-unknown` | `dtolnay/rust-toolchain@stable` |
+| **wasm-pack** | Only for `task ci` / `task install` (not for GitHub CI’s Docker path) |
 
 ```bash
 task ci
 ```
 
-That runs, in order: `install:ci` (dependency) then `cortex:check`, `core:clippy`, `web:format:check`, `web:check`, `web:lint`, `web:knip`, `core:test`, `web:test`, `web:test:e2e` — see the root `Taskfile.yml` `ci` task. No workflow YAML change is needed when you add steps there; only change [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) if the **runner environment** (versions, caches, secrets) must change.
+That runs `install:ci` then `cortex:check`, `core:clippy`, web checks, `core:test`, `web:test`, `web:test:e2e` — see [`Taskfile.ci.yml`](../Taskfile.ci.yml) task **`ci:full`** (root `task ci` delegates to it).
+
+Change [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) when the **Docker / runner environment** (caching, permissions, Node/Rust versions for `ci:docker`) must change.
 
 ---
 
@@ -29,7 +37,7 @@ That runs, in order: `install:ci` (dependency) then `cortex:check`, `core:clippy
 
 | Workflow file | Trigger | Job | What it does |
 |---------------|---------|-----|--------------|
-| [`ci.yml`](../.github/workflows/ci.yml) | PR to `main`, push to `main` | `test` | Full quality gate (`task ci`) |
+| [`ci.yml`](../.github/workflows/ci.yml) | PR to `main`, push to `main` | `ci` | Docker `buildx bake ci` (GHA cache) + cache verification + `task ci:docker` |
 | [`deploy.yml`](../.github/workflows/deploy.yml) | Push to `main`, manual dispatch | `deploy` | Build + publish to GitHub Pages |
 | [`preview.yml`](../.github/workflows/preview.yml) | PR opened / updated / closed | `preview` | Build + publish ephemeral PR preview |
 | [`cortex-gardening.yml`](../.github/workflows/cortex-gardening.yml) | Weekly (Mon 09:00 UTC), manual | `gardening` | `cursor-agent` drift check → optional GitHub issue |
@@ -40,26 +48,31 @@ That runs, in order: `install:ci` (dependency) then `cortex:check`, `core:clippy
 
 Runs on every PR and every push to `main`. A PR **must** pass this before merge.
 
-**Runner steps:** checkout → Node 20 + npm cache (`me-ai-web/package.json`) → Rust stable + wasm32 → wasm-pack (curl installer) → Task → **`task ci`**.
+**Permissions:** `contents: read`, **`actions: write`** (required so BuildKit can use the [`type=gha` cache backend](https://docs.docker.com/build/cache/backends/gha/)).
 
-**What `task ci` does (in order):**
+**Runner steps (summary):**
 
-1. `install:ci` — `core:build` (wasm-pack) + `npm install` with one-retry esbuild workaround + `web:copy-core`
-2. `cortex:check` — Rust binary verifies `.cortex/` link integrity and store inventory (see [rust-tooling.md](references/rust-tooling.md))
-3. `core:clippy` — Rust lints on `wasm32-unknown-unknown` target, `-D warnings`
-4. `web:format:check` — Prettier formatting check on `me-ai-web/src/`
-5. `web:check` — `svelte-check` (TypeScript + Svelte types)
-6. `web:lint` — ESLint on `me-ai-web/src/`
-7. `web:knip` — dead code / unused exports detection
-8. `core:test` — Rust unit tests (`cargo test --lib`)
-9. `web:test` — Vitest (`vitest run`)
-10. `web:test:e2e` — Playwright E2E against a dev server (Chromium)
+1. **Docker Buildx** — `docker buildx bake ci` with `CACHE_GHA=1` (see [`docker-bake.hcl`](../docker-bake.hcl) group **`ci`**): builds **`web-image`**, runs **`rust-test`** and **`wasm-clippy`** stages, exports wasm **`pkg`** to `me-ai-core/pkg-docker/` via **`wasm-local`**.
+2. **Cache verification** — Immediately runs `docker buildx bake web-image --progress=plain` again and **fails** if fewer than **8** log lines contain `CACHED` (guards against a broken or disabled BuildKit cache on the runner).
+3. **Sync pkg** — `cp` from `me-ai-core/pkg-docker/` into `me-ai-core/pkg/` for the `file:` dependency.
+4. **Node 20** + npm cache, **Rust stable** + wasm32 (for `cortex-check` and toolchain consistency), **Task** → **`task ci:docker`**.
 
-Task names follow the `<namespace>:<task>` convention — see [taskfile-architecture.md](references/taskfile-architecture.md).
+**What runs in Docker vs `ci:docker`:**
 
-**Environment:** Ubuntu `ubuntu-latest`, Node 20, Rust stable + `wasm32-unknown-unknown`, wasm-pack (curl installer).
+| Step | Where |
+|------|--------|
+| wasm-pack production build, Vite production build | Dockerfile → `web-image` |
+| `cargo test --lib` | Dockerfile → `rust-test` |
+| `cargo clippy` wasm32 `-D warnings` | Dockerfile → `wasm-clippy` |
+| `web:install:ci`, `cortex:check`, Prettier, svelte-check, ESLint, knip, Vitest, Playwright | `task ci:docker` on the runner |
 
-If any step fails, the workflow fails. There are no skipped steps in CI (Playwright may report individual tests as skipped by design).
+**`ci:docker`** ([`Taskfile.ci.yml`](../Taskfile.ci.yml)) runs, in order: `web:install:ci`, `cortex:check`, `web:format:check`, `web:check`, `web:lint`, `web:knip`, `web:test`, `web:test:e2e`.
+
+**Caching:** With `CACHE_GHA=1`, bake uses **`cache-from` / `cache-to` `type=gha,scope=me-ai`** so layers persist across workflow runs. **Fork PRs** set **`CACHE_GHA_RO=1`** (no `cache-to`) because the token cannot write Actions cache; they still **read** cache when GitHub allows.
+
+**Native equivalent:** `task ci` still exists for local full-native runs (includes `install:ci`, `core:clippy`, `core:test`). Task names follow the `<namespace>:<task>` convention — see [taskfile-architecture.md](references/taskfile-architecture.md).
+
+If any step fails, the workflow fails. Playwright may report individual tests as skipped by design.
 
 ---
 
@@ -100,10 +113,11 @@ Uses `rossjrw/pr-preview-action` which posts the preview URL as a PR comment and
 
 | Tool | CI (`ci.yml`) | Deploy / preview |
 |------|----------------|------------------|
-| Node 20 | `actions/setup-node@v4` + npm cache on `me-ai-web/package.json` | Same; **deploy** omits `cache: npm` so `file:../me-ai-core/pkg` is never stale |
-| Rust + wasm32 | `dtolnay/rust-toolchain@stable` | Same |
-| wasm-pack | **curl** official installer | `jetli/wasm-pack-action@v0.4.0` |
-| Task | `arduino/setup-task@v2` | Same |
+| Docker / Buildx | `docker/setup-buildx-action@v3`; **`docker buildx bake ci`** + GHA cache | — |
+| Node 20 | After Docker bake: `actions/setup-node@v4` + npm cache on `me-ai-web/package.json` | Same; **deploy** omits `cache: npm` so `file:../me-ai-core/pkg` is never stale |
+| Rust + wasm32 | After Docker: `dtolnay/rust-toolchain@stable` (cortex-check; core already built in Docker) | Same |
+| wasm-pack | Not installed on CI (WASM built in Docker) | `jetli/wasm-pack-action@v0.4.0` |
+| Task | `arduino/setup-task@v2` → **`task ci:docker`** | Same |
 
 ---
 
@@ -141,7 +155,38 @@ Tasks are split across package Taskfiles — see [taskfile-architecture.md](refe
 
 To add a new check:
 1. Add the task to the relevant package Taskfile (e.g. `me-ai-web/Taskfile.yml`)
-2. Add it to the `ci` task's `cmds` list in the root `Taskfile.yml` using its namespaced name
-3. The GitHub Actions workflow picks it up automatically — no YAML change needed
+2. Add it to the **`ci:docker`** and/or **`ci:full`** task `cmds` in [`Taskfile.ci.yml`](../Taskfile.ci.yml) (GitHub uses `ci:docker`; native `task ci` uses `ci:full` via the root alias).
+3. If the check belongs in Docker (Rust compile, new binary test), extend the [`Dockerfile`](../Dockerfile) and [`docker-bake.hcl`](../docker-bake.hcl) group **`ci`** as needed.
 
-Only touch `.github/workflows/` if you need to change triggers, environment, secrets, or external actions.
+Touch [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) when changing Docker setup, cache verification, or runner tool versions for `ci:docker`. Other workflow files: triggers, secrets, external actions.
+
+---
+
+## Docker builds (optional)
+
+Container builds use the repo-root [`Dockerfile`](../Dockerfile) and [`docker-bake.hcl`](../docker-bake.hcl). **Orchestration is Task** via [`Taskfile.docker.yml`](../Taskfile.docker.yml) (included as `docker:*` from the root Taskfile). **GitHub CI** runs `docker buildx bake ci` with **`CACHE_GHA=1`** (and **`CACHE_GHA_RO=1`** on fork PRs) for the [GHA cache backend](https://docs.docker.com/build/cache/backends/gha/); locally use **`PUSH_CACHE=1`** for registry cache writes or leave both unset for offline builds.
+
+| Artifact | Notes |
+|----------|--------|
+| Rust toolchain | `rust:bookworm` — Docker’s **latest stable** Rust on Debian bookworm (`ARG RUST_VERSION=bookworm`; pin with e.g. `1.85.0-bookworm` via build-arg). |
+| Rust **build cache** | **[cargo-chef](https://github.com/LukeMathWalker/cargo-chef):** `chef-planner` builds a recipe from `Cargo.toml` + a stub `src/lib.rs` (so the heavy **dependency** layer rebuilds only when dependencies change, not when application Rust changes). `chef-cacher` runs `cargo chef cook` for `wasm32-unknown-unknown`. **`wasm-builder`** copies that `target/` then the real `me-ai-core/` sources and runs `wasm-pack` (incremental compile for the crate). **BuildKit cache mounts** on `cargo` registry/git speed repeated fetches; `rust-test` also mounts registry/git/`target` for repeated native test runs. Dockerfile uses `# syntax=docker/dockerfile:1` so cache mounts resolve. |
+| Final **`web` image** | Node 20 slim + global [`serve`](https://www.npmjs.com/package/serve) on port **3000** (`-s dist` for SPA fallback). No nginx. |
+| Bake outputs | `wasm-output` / `web-output` scratch stages for exporting artifacts |
+
+**Optional (repo policy):** committing a **`Cargo.lock`** for `me-ai-core` (even if the crate stays unpublished) makes dependency versions fully pinned for chef and for local `cargo`; today the lockfile is gitignored, so Docker resolves semver ranges at build time like a fresh `cargo build`.
+
+**Commands** (repo root, Docker running):
+
+```bash
+task docker:build                    # load $(REGISTRY)/web:latest (default REGISTRY=me-ai)
+task docker:run                       # build + run → http://localhost:8080
+task docker:push PUSH_CACHE=1          # push + remote cache (after registry login)
+task docker:web-local                 # dist → me-ai-web/dist-docker/
+task docker:wasm-local                # pkg → me-ai-core/pkg-docker/
+task docker:rust-test                 # core lib tests in a Rust stage
+task docker:bake-ci CACHE_GHA=1       # same targets as CI (GHA cache when env set)
+```
+
+Override image prefix: `task docker:build REGISTRY=ghcr.io/myorg`.
+
+The **CI** workflow is Docker-first for Rust/WASM/Vite; see § CI ([`ci.yml`](../.github/workflows/ci.yml)).

--- a/.cortex/index.md
+++ b/.cortex/index.md
@@ -11,7 +11,7 @@ Read this file, then follow the links relevant to your task.
 | [`core-beliefs.md`](core-beliefs.md) | Golden principles governing every line of code |
 | [`design-docs/`](design-docs/index.md) | n8n architecture, plugin system, event stream model |
 | [`product-specs/`](product-specs/index.md) | Three-step user flow, feature specs |
-| [`ci-cd.md`](ci-cd.md) | GitHub Actions workflows, deploy targets, how to add CI steps |
+| [`ci-cd.md`](ci-cd.md) | GitHub Actions workflows, deploy targets, optional Docker (Task + bake), how to add CI steps |
 | [`quality-score.md`](quality-score.md) | Health grades per domain |
 | [`tech-debt-tracker.md`](tech-debt-tracker.md) | Known debt items |
 | [`exec-plans/`](exec-plans/README.md) | Execution plans for complex work |

--- a/.cortex/references/rust-tooling.md
+++ b/.cortex/references/rust-tooling.md
@@ -56,7 +56,7 @@ Run locally: `task cortex:check`
 1. Create `tools/<name>/Cargo.toml` with `edition = "2021"` and `[[bin]]`.
 2. Write `tools/<name>/src/main.rs` — no external crates unless essential; prefer `std`.
 3. Add a Taskfile task: `cargo run --manifest-path tools/<name>/Cargo.toml`.
-4. If it should run in CI, add it to the `ci` task in `Taskfile.yml`.
+4. If it should run in CI, add it to **`ci:full`** and/or **`ci:docker`** in [`Taskfile.ci.yml`](../../Taskfile.ci.yml) (see [ci-cd.md](../ci-cd.md)).
 
 ## Exceptions
 

--- a/.cortex/references/taskfile-architecture.md
+++ b/.cortex/references/taskfile-architecture.md
@@ -1,17 +1,37 @@
 # Taskfile architecture
 
-The root `Taskfile.yml` is an **orchestration layer only** — it contains no inline task logic.
+The root `Taskfile.yml` is the **orchestration layer**: it wires included namespaces and defines
+cross-package flows.
 All package-level tasks live in the Taskfile of the package that owns them, then get included
 into the root under a namespace.
 
 ## Structure
 
 ```
-Taskfile.yml                        ← root: includes + orchestration tasks
+Taskfile.yml                        ← root: includes + cross-package orchestration only
+Taskfile.ci.yml                     ← included as  ci:*  (repo root, dir: .)
+Taskfile.docker.yml                 ← included as  docker:*  (repo root, dir: .)
 me-ai-core/Taskfile.yml             ← included as  core:*
 me-ai-web/Taskfile.yml              ← included as  web:*
 tools/cortex-check/Taskfile.yml     ← included as  cortex:*
 ```
+
+## Namespaced task groups
+
+**Prohibited:** Defining tasks in the **root** `Taskfile.yml` whose YAML keys look like a namespace plus task name (e.g. `docker:build:`, `docker:rust-test:`). That duplicates what Task’s `includes` already provides and clutters the orchestration file.
+
+**Required:** For a cohesive tool group (Docker, CI pipelines, etc.), add a **separate Taskfile** and include it:
+
+```yaml
+includes:
+  docker:
+    taskfile: ./Taskfile.docker.yml
+    dir: .
+```
+
+Inside that file, task names are **short** (`build`, `rust-test`, `web-local`). Invocations are still `task docker:build`, `task docker:rust-test` — the `docker:` prefix comes **only** from the include key, not from hand-written colonated names in the root.
+
+**Not covered by this rule:** Root tasks like `install:ci` or `deploy-build` that are true cross-package orchestration steps (single flow, not a whole sub-tooling surface). Prefer short, descriptive root names where possible; use a dedicated included Taskfile when a **family** of related commands appears.
 
 ## Namespaces and working directories
 
@@ -20,6 +40,8 @@ tools/cortex-check/Taskfile.yml     ← included as  cortex:*
 | `core:*` | `me-ai-core/Taskfile.yml` | `me-ai-core/` |
 | `web:*` | `me-ai-web/Taskfile.yml` | `me-ai-web/` |
 | `cortex:*` | `tools/cortex-check/Taskfile.yml` | repo root |
+| `docker:*` | `Taskfile.docker.yml` | repo root |
+| `ci:*` | `Taskfile.ci.yml` | repo root |
 
 The `dir` is set on the `includes` entry in the root Taskfile (not repeated in each task).
 This means tasks in `me-ai-core/Taskfile.yml` can write `cargo build .` instead of
@@ -27,6 +49,7 @@ This means tasks in `me-ai-core/Taskfile.yml` can write `cargo build .` instead 
 
 Tools under `tools/` that need to reference paths relative to the repo root (like
 `cortex-check`) are included without a `dir` override so they run from the repo root.
+`docker:*` and `ci:*` use `dir: .` so commands see the repo root as context.
 
 ## Task reference
 
@@ -40,8 +63,31 @@ Single-package tasks belong in their own Taskfile.
 | `install` | `core:build` (dep) → `web:install` |
 | `install:ci` | `core:build` (dep) → `web:install:ci` |
 | `restart` | Wipes `me-ai-core/pkg` → `core:build` → `web:copy-core` → `web:kill-dev` → `web:dev` |
-| `ci` | Full pipeline — see [ci-cd.md](../ci-cd.md) |
+| `ci` | Thin alias → **`ci:full`** ([`Taskfile.ci.yml`](../../Taskfile.ci.yml)) |
 | `deploy-build` | `install:ci` → `web:build` |
+
+### `ci:*` ([`Taskfile.ci.yml`](../../Taskfile.ci.yml))
+
+CI pipelines only; may call `core:*`, `web:*`, and `cortex:*`. See [ci-cd.md](../ci-cd.md).
+
+| Task | What it does |
+|------|--------------|
+| `ci:full` | `install:ci` (dep) → cortex + `core:clippy` + web checks + `core:test` + `web:test` + `web:test:e2e` |
+| `ci:docker` | After Docker populated `me-ai-core/pkg`: `web:install:ci` → cortex + web checks/tests (no `core:build` / `core:clippy` / `core:test`) |
+
+### `docker:*` ([`Taskfile.docker.yml`](../../Taskfile.docker.yml))
+
+Vars: `REGISTRY` (default `me-ai`), `PUSH_CACHE` (optional registry cache write). See [ci-cd.md](../ci-cd.md) § Docker builds.
+
+| Task | What it does |
+|------|--------------|
+| `docker:build` | `docker buildx bake --load default` |
+| `docker:push` | `docker buildx bake --push default` |
+| `docker:run` | `docker:build` (dep) → `docker run` (host 8080 → container 3000) |
+| `docker:web-local` | Bake `web-output` → `me-ai-web/dist-docker/` |
+| `docker:wasm-local` | Bake `wasm-output` → `me-ai-core/pkg-docker/` |
+| `docker:rust-test` | Bake `rust-test` stage (`cargo test --lib` in core) |
+| `docker:bake-ci` | `docker buildx bake ci` (same targets as GitHub Actions; set `CACHE_GHA=1` for GHA cache backend) |
 
 ### `core:*` (me-ai-core/Taskfile.yml)
 
@@ -76,20 +122,18 @@ Single-package tasks belong in their own Taskfile.
 
 ## Adding a new package or tool
 
-1. Create `<location>/Taskfile.yml` with `version: "3"` and the package's tasks.
+1. Create `<location>/Taskfile.yml` with `version: "3"` and the package's tasks (or a root-level `Taskfile.<group>.yml` for repo-root tools like Docker).
 2. Add an entry under `includes:` in the root `Taskfile.yml`:
    ```yaml
    includes:
      <namespace>:
        taskfile: ./<location>/Taskfile.yml
-       dir: ./<location>   # omit if the tool needs to run from repo root
+       dir: ./<location>   # use `.` if commands must run from repo root (e.g. docker)
    ```
 3. Reference the tasks in root orchestration tasks using `<namespace>:<task>`.
 4. Run `task --list` to confirm everything resolves.
 
 **Rule:** a task belongs in the root only if it coordinates across multiple namespaces.
-The moment it only touches one package, move it to that package's Taskfile.
+The moment it only touches one package — or forms a **group** of same-domain commands (Docker, …) — move it to that package’s Taskfile or to a dedicated included file (see **Namespaced task groups** above).
 
-**Constraint:** included Taskfiles cannot reference sibling namespaces. Only the root can call
-`core:*`, `web:*`, and `cortex:*` together — which is exactly why cross-package orchestration
-tasks must live in root.
+**Constraint:** package Taskfiles (`me-ai-core/`, `me-ai-web/`, …) **cannot** reference sibling namespaces. **Root** and repo-root includes **`ci:*`** and **`docker:*`** are where cross-namespace orchestration lives: `ci:*` may call `core:*`, `web:*`, and `cortex:*`; `docker:*` runs Buildx only. Keep **short** task names inside each included file.

--- a/.cortex/references/taskfile-architecture.md
+++ b/.cortex/references/taskfile-architecture.md
@@ -68,7 +68,7 @@ Single-package tasks belong in their own Taskfile.
 
 ### `ci:*` ([`Taskfile.ci.yml`](../../Taskfile.ci.yml))
 
-CI pipelines only; may call `core:*`, `web:*`, and `cortex:*`. See [ci-cd.md](../ci-cd.md).
+CI pipelines only. Tasks invoke other namespaces via **shell** lines (`task web:install:ci`, …) because a `task:` step like `web:install:ci` would wrongly resolve to `ci:web:install:ci` under this include. See [ci-cd.md](../ci-cd.md).
 
 | Task | What it does |
 |------|--------------|

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+**/.cursor
+**/.DS_Store
+**/node_modules
+**/target
+me-ai-core/pkg
+me-ai-web/dist
+**/playwright-report
+**/test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,45 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    env:
+      CACHE_GHA: "1"
+      # Fork PRs cannot write Actions cache; still read upstream cache when available.
+      CACHE_GHA_RO: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && '1' || '' }}
+      REGISTRY: me-ai
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker bake (web image, rust tests, wasm clippy, wasm pkg export)
+        run: docker buildx bake ci
+
+      - name: Verify BuildKit cache reuse (second web-image bake)
+        run: |
+          set -euo pipefail
+          docker buildx bake web-image --progress=plain 2>&1 | tee /tmp/bake-verify.log
+          n=$(grep -c CACHED /tmp/bake-verify.log || true)
+          echo "Lines containing CACHED in second web-image bake: $n"
+          if [ "$n" -lt 8 ]; then
+            echo "::error::Expected cache-heavy second bake (>=8 CACHED lines); got $n. BuildKit may not be reusing layers."
+            exit 1
+          fi
+
+      - name: Sync wasm pkg from Docker export for web install
+        run: |
+          mkdir -p me-ai-core/pkg
+          cp -a me-ai-core/pkg-docker/. me-ai-core/pkg/
 
       - uses: actions/setup-node@v4
         with:
@@ -22,9 +56,7 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
       - uses: arduino/setup-task@v2
 
-      - run: task ci
+      - name: Web install + checks (Rust build, clippy, and tests already ran in Docker)
+        run: task ci:docker

--- a/.github/workflows/cortex-gardening.yml
+++ b/.github/workflows/cortex-gardening.yml
@@ -74,7 +74,7 @@ jobs:
           The .cortex/ directory is the single source of truth for this project:
           - .cortex/architecture.md — package map, code navigation
           - .cortex/core-beliefs.md — golden principles every agent must follow
-          - .cortex/ci-cd.md — GitHub Actions workflows, what task ci does
+          - .cortex/ci-cd.md — GitHub Actions workflows, Taskfile.ci.yml (ci:full / ci:docker)
           - .cortex/quality-score.md — living quality grades per domain
           - .cortex/tech-debt-tracker.md — active debt items
           - .cortex/references/rexie-patterns.md — IndexedDB store inventory and conventions

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ node_modules
 
 # Built artifacts (not committed)
 me-ai-core/pkg
+me-ai-core/pkg-docker
+me-ai-web/dist-docker
 me-ai-web/public/wasm
 
 tools/*/target

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 # --- Clippy (wasm32; same chef target/ as wasm-builder — CI runs this in Docker) ---
 FROM rust:${RUST_VERSION} AS wasm-clippy
-RUN rustup target add wasm32-unknown-unknown
+RUN rustup target add wasm32-unknown-unknown \
+    && rustup component add clippy
 WORKDIR /build/me-ai-core
 COPY --from=chef-cacher /build/me-ai-core/target target
 COPY me-ai-core/ .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,92 @@
+# syntax=docker/dockerfile:1
+# ============================================================
+# Multi-stage Dockerfile for me-ai (Rust WASM core + Vite web)
+# Rust deps: cargo-chef (cached layer when Cargo.toml unchanged) + BuildKit
+# cache mounts on wasm-pack / cargo test for registry + incremental artifacts.
+# ============================================================
+# RUST_VERSION defaults to `bookworm` → rust:bookworm (latest stable Rust on Debian bookworm).
+# Override to pin, e.g. --build-arg RUST_VERSION=1.85.0-bookworm
+# ============================================================
+
+ARG RUST_VERSION=bookworm
+
+# --- cargo-chef: dependency recipe (stub lib.rs — invalidates only when Cargo.toml changes) ---
+FROM rust:${RUST_VERSION} AS chef-planner
+RUN cargo install cargo-chef --locked
+WORKDIR /build/me-ai-core
+COPY me-ai-core/Cargo.toml .
+RUN mkdir -p src && \
+    printf '%s\n' '// cargo-chef stub; real sources are copied in wasm-builder' > src/lib.rs && \
+    printf '%s\n' 'pub fn _chef_dependency_stub() {}' >> src/lib.rs
+RUN cargo chef prepare --recipe-path recipe.json
+
+# --- cargo-chef: compile all third-party crates for wasm32 (heavy layer; reuse until recipe changes) ---
+FROM rust:${RUST_VERSION} AS chef-cacher
+RUN rustup target add wasm32-unknown-unknown \
+    && cargo install cargo-chef --locked
+WORKDIR /build/me-ai-core
+COPY --from=chef-planner /build/me-ai-core/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo chef cook --release --target wasm32-unknown-unknown --recipe-path recipe.json
+
+# --- WASM pkg: reuse chef target/ + BuildKit caches for incremental me-ai-core compile ---
+FROM rust:${RUST_VERSION} AS wasm-builder
+RUN rustup target add wasm32-unknown-unknown \
+    && cargo install wasm-pack --version 0.13.1 --locked
+WORKDIR /build/me-ai-core
+COPY --from=chef-cacher /build/me-ai-core/target target
+COPY me-ai-core/ .
+# Do not mount cache on `target/` here — it would hide the prebuilt deps from chef-cacher.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    wasm-pack build . --target web --out-dir pkg
+
+# --- Clippy (wasm32; same chef target/ as wasm-builder — CI runs this in Docker) ---
+FROM rust:${RUST_VERSION} AS wasm-clippy
+RUN rustup target add wasm32-unknown-unknown
+WORKDIR /build/me-ai-core
+COPY --from=chef-cacher /build/me-ai-core/target target
+COPY me-ai-core/ .
+RUN cargo clippy --target wasm32-unknown-unknown -- -D warnings
+
+# --- Web: Vite production build ---
+FROM node:20-bookworm AS web-build
+
+WORKDIR /build/me-ai-web
+COPY me-ai-web/package.json ./
+RUN mkdir -p node_modules/me-ai-core
+COPY --from=wasm-builder /build/me-ai-core/pkg ./node_modules/me-ai-core/
+RUN npm install --foreground-scripts
+COPY me-ai-web/ ./
+
+ENV VITE_BASE=/
+RUN npm run build
+
+# --- Runtime: static dist via `serve` (SPA rewrite, no nginx) ---
+FROM node:20-bookworm-slim AS web
+
+WORKDIR /app
+RUN npm install -g serve@14
+COPY --from=web-build /build/me-ai-web/dist ./dist
+
+EXPOSE 3000
+CMD ["serve", "-s", "dist", "-l", "3000"]
+
+# --- Extract wasm pkg only (e.g. local sync or inspection) ---
+FROM scratch AS wasm-output
+COPY --from=wasm-builder /build/me-ai-core/pkg/ /
+
+# --- Extract Vite dist only (e.g. deploy without loading full image) ---
+FROM scratch AS web-output
+COPY --from=web-build /build/me-ai-web/dist/ /
+
+# --- Rust unit tests (native target; cache mounts — separate target dir from wasm) ---
+FROM rust:${RUST_VERSION} AS rust-test
+
+WORKDIR /build/me-ai-core
+COPY me-ai-core/ .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/me-ai-core/target \
+    cargo test --lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,8 @@ FROM node:20-bookworm AS web-build
 
 WORKDIR /build/me-ai-web
 COPY me-ai-web/package.json ./
+# postinstall runs scripts/ensure-tslib.cjs and ensure-core.cjs before full tree copy
+COPY me-ai-web/scripts ./scripts/
 RUN mkdir -p node_modules/me-ai-core
 COPY --from=wasm-builder /build/me-ai-core/pkg ./node_modules/me-ai-core/
 RUN npm install --foreground-scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,9 @@ WORKDIR /build/me-ai-web
 COPY me-ai-web/package.json ./
 # postinstall runs scripts/ensure-tslib.cjs and ensure-core.cjs before full tree copy
 COPY me-ai-web/scripts ./scripts/
-RUN mkdir -p node_modules/me-ai-core
-COPY --from=wasm-builder /build/me-ai-core/pkg ./node_modules/me-ai-core/
+# package.json uses file:../me-ai-core/pkg — layout must match repo (sibling me-ai-core/pkg)
+RUN mkdir -p /build/me-ai-core/pkg
+COPY --from=wasm-builder /build/me-ai-core/pkg /build/me-ai-core/pkg/
 RUN npm install --foreground-scripts
 COPY me-ai-web/ ./
 

--- a/Taskfile.ci.yml
+++ b/Taskfile.ci.yml
@@ -1,6 +1,7 @@
 # https://taskfile.dev
 # CI pipelines — included from root Taskfile.yml as namespace `ci:`.
-# Invoke: `task ci` (alias → ci:full), `task ci:full`, `task ci:docker`.
+# Cross-namespace calls use shell `task …` because `task: web:foo` inside this
+# file would incorrectly resolve to `ci:web:foo`.
 version: "3"
 
 tasks:
@@ -9,29 +10,28 @@ tasks:
       Full native CI pipeline:
       install:ci → cortex:check → core:clippy → web:format:check →
       web:check → web:lint → web:knip → core:test → web:test → web:test:e2e
-    deps:
-      - task: install:ci
     cmds:
-      - task: cortex:check
-      - task: core:clippy
-      - task: web:format:check
-      - task: web:check
-      - task: web:lint
-      - task: web:knip
-      - task: core:test
-      - task: web:test
-      - task: web:test:e2e
+      - task install:ci
+      - task cortex:check
+      - task core:clippy
+      - task web:format:check
+      - task web:check
+      - task web:lint
+      - task web:knip
+      - task core:test
+      - task web:test
+      - task web:test:e2e
 
   docker:
     desc: >
       CI after Docker bake populated me-ai-core/pkg (GitHub Actions path).
       Skips core:build, core:clippy, core:test — those run inside the Dockerfile.
     cmds:
-      - task: web:install:ci
-      - task: cortex:check
-      - task: web:format:check
-      - task: web:check
-      - task: web:lint
-      - task: web:knip
-      - task: web:test
-      - task: web:test:e2e
+      - task web:install:ci
+      - task cortex:check
+      - task web:format:check
+      - task web:check
+      - task web:lint
+      - task web:knip
+      - task web:test
+      - task web:test:e2e

--- a/Taskfile.ci.yml
+++ b/Taskfile.ci.yml
@@ -1,0 +1,37 @@
+# https://taskfile.dev
+# CI pipelines — included from root Taskfile.yml as namespace `ci:`.
+# Invoke: `task ci` (alias → ci:full), `task ci:full`, `task ci:docker`.
+version: "3"
+
+tasks:
+  full:
+    desc: >
+      Full native CI pipeline:
+      install:ci → cortex:check → core:clippy → web:format:check →
+      web:check → web:lint → web:knip → core:test → web:test → web:test:e2e
+    deps:
+      - task: install:ci
+    cmds:
+      - task: cortex:check
+      - task: core:clippy
+      - task: web:format:check
+      - task: web:check
+      - task: web:lint
+      - task: web:knip
+      - task: core:test
+      - task: web:test
+      - task: web:test:e2e
+
+  docker:
+    desc: >
+      CI after Docker bake populated me-ai-core/pkg (GitHub Actions path).
+      Skips core:build, core:clippy, core:test — those run inside the Dockerfile.
+    cmds:
+      - task: web:install:ci
+      - task: cortex:check
+      - task: web:format:check
+      - task: web:check
+      - task: web:lint
+      - task: web:knip
+      - task: web:test
+      - task: web:test:e2e

--- a/Taskfile.docker.yml
+++ b/Taskfile.docker.yml
@@ -1,0 +1,69 @@
+# https://taskfile.dev
+# Docker Buildx bake — included from root Taskfile.yml as namespace `docker:`.
+# Task names here are short (build, run, …); invoke as `task docker:build`, etc.
+version: "3"
+
+vars:
+  REGISTRY: me-ai
+  PUSH_CACHE: ""
+  CACHE_GHA: ""
+  CACHE_GHA_RO: ""
+
+tasks:
+  bake-ci:
+    desc: "docker buildx bake ci (web-image, rust-test, wasm-clippy, wasm-local) — set CACHE_GHA=1 in GHA"
+    env:
+      REGISTRY: "{{.REGISTRY}}"
+      CACHE_GHA: "{{.CACHE_GHA}}"
+      CACHE_GHA_RO: "{{.CACHE_GHA_RO}}"
+      PUSH_CACHE: "{{.PUSH_CACHE}}"
+    cmds:
+      - docker buildx bake ci
+
+  build:
+    desc: "docker buildx bake --load default → REGISTRY/web:latest"
+    env:
+      REGISTRY: "{{.REGISTRY}}"
+    cmds:
+      - docker buildx bake --load default
+
+  push:
+    desc: "docker buildx bake --push default (set PUSH_CACHE=1 to write registry cache)"
+    env:
+      REGISTRY: "{{.REGISTRY}}"
+      PUSH_CACHE: "{{.PUSH_CACHE}}"
+    cmds:
+      - docker buildx bake --push default
+
+  web-local:
+    desc: Export Vite dist to me-ai-web/dist-docker/
+    env:
+      REGISTRY: "{{.REGISTRY}}"
+    cmds:
+      - docker buildx bake web-local
+
+  wasm-local:
+    desc: Export wasm pkg to me-ai-core/pkg-docker/
+    env:
+      REGISTRY: "{{.REGISTRY}}"
+    cmds:
+      - docker buildx bake wasm-local
+
+  rust-test:
+    desc: Run me-ai-core cargo test --lib in a Docker stage (cache-only output)
+    env:
+      REGISTRY: "{{.REGISTRY}}"
+      PUSH_CACHE: "{{.PUSH_CACHE}}"
+    cmds:
+      - docker buildx bake rust-test
+
+  run:
+    desc: "docker:build then run web image at http://localhost:8080"
+    env:
+      REGISTRY: "{{.REGISTRY}}"
+    deps:
+      - task: build
+        vars:
+          REGISTRY: "{{.REGISTRY}}"
+    cmds:
+      - docker run --rm -p 8080:3000 {{.REGISTRY}}/web:latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,6 +6,8 @@
 #   core:*    me-ai-core/Taskfile.yml   (runs from me-ai-core/)
 #   web:*     me-ai-web/Taskfile.yml    (runs from me-ai-web/)
 #   cortex:*  tools/cortex-check/Taskfile.yml  (runs from repo root)
+#   docker:*  Taskfile.docker.yml  (repo root; Buildx bake — see docker-bake.hcl)
+#   ci:*      Taskfile.ci.yml       (repo root; native + Docker-backed CI pipelines)
 version: "3"
 
 includes:
@@ -17,6 +19,12 @@ includes:
     dir: ./me-ai-web
   cortex:
     taskfile: ./tools/cortex-check/Taskfile.yml
+  docker:
+    taskfile: ./Taskfile.docker.yml
+    dir: .
+  ci:
+    taskfile: ./Taskfile.ci.yml
+    dir: .
 
 tasks:
   default:
@@ -49,24 +57,11 @@ tasks:
       - task: web:kill-dev
       - task: web:dev
 
-  # Cross-package: calls tasks from core:, web:, and cortex: namespaces.
+  # Alias: root `task ci` → included `ci:full` (Taskfile.ci.yml).
   ci:
-    desc: >
-      Full CI pipeline:
-      install:ci → cortex:check → core:clippy → web:format:check →
-      web:check → web:lint → web:knip → core:test → web:test → web:test:e2e
-    deps:
-      - task: install:ci
+    desc: "Native full CI — delegates to ci:full (see Taskfile.ci.yml)"
     cmds:
-      - task: cortex:check
-      - task: core:clippy
-      - task: web:format:check
-      - task: web:check
-      - task: web:lint
-      - task: web:knip
-      - task: core:test
-      - task: web:test
-      - task: web:test:e2e
+      - task: ci:full
 
   deploy-build:
     desc: "install:ci → web:build (used by deploy and preview workflows)"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,93 @@
+variable "REGISTRY" {
+  default = "me-ai"
+}
+
+// Set PUSH_CACHE=1 to enable writing cache to registry (local push / some CI)
+variable "PUSH_CACHE" {
+  default = ""
+}
+
+// Set CACHE_GHA=1 in GitHub Actions for type=gha cache (requires actions: write on same-repo runs)
+variable "CACHE_GHA" {
+  default = ""
+}
+
+// Set CACHE_GHA_RO=1 for fork PRs (cache-from gha only; no cache-to — token cannot write)
+variable "CACHE_GHA_RO" {
+  default = ""
+}
+
+group "default" {
+  targets = ["web-image"]
+}
+
+// Shared BuildKit cache config: GitHub Actions vs registry vs none
+function "cache_from" {
+  params = []
+  result = CACHE_GHA != "" ? [
+    "type=gha,scope=me-ai",
+  ] : [
+    "type=registry,ref=${REGISTRY}/web:cache",
+    "type=registry,ref=${REGISTRY}/core-wasm:cache",
+  ]
+}
+
+function "cache_to" {
+  params = []
+  result = CACHE_GHA != "" ? (
+    CACHE_GHA_RO != "" ? [] : [
+      "type=gha,scope=me-ai,mode=max",
+    ]
+  ) : PUSH_CACHE != "" ? [
+    "type=registry,ref=${REGISTRY}/web:cache,mode=max",
+  ] : []
+}
+
+target "web-image" {
+  context      = "."
+  dockerfile   = "Dockerfile"
+  target       = "web"
+  tags         = ["${REGISTRY}/web:latest"]
+  cache-from   = cache_from()
+  cache-to     = cache_to()
+}
+
+target "web-local" {
+  context      = "."
+  dockerfile   = "Dockerfile"
+  target       = "web-output"
+  output       = ["type=local,dest=me-ai-web/dist-docker"]
+  cache-from   = cache_from()
+  cache-to     = cache_to()
+}
+
+target "wasm-local" {
+  context      = "."
+  dockerfile   = "Dockerfile"
+  target       = "wasm-output"
+  output       = ["type=local,dest=me-ai-core/pkg-docker"]
+  cache-from   = cache_from()
+  cache-to     = cache_to()
+}
+
+target "rust-test" {
+  context      = "."
+  dockerfile   = "Dockerfile"
+  target       = "rust-test"
+  output       = ["type=cacheonly"]
+  cache-from   = cache_from()
+  cache-to     = cache_to()
+}
+
+target "wasm-clippy" {
+  context      = "."
+  dockerfile   = "Dockerfile"
+  target       = "wasm-clippy"
+  output       = ["type=cacheonly"]
+  cache-from   = cache_from()
+  cache-to     = cache_to()
+}
+
+group "ci" {
+  targets = ["web-image", "rust-test", "wasm-clippy", "wasm-local"]
+}


### PR DESCRIPTION
## Summary
- **GitHub CI** builds Rust/WASM/Vite via `docker buildx bake ci` (cargo-chef, wasm-pack, clippy, rust-test, wasm pkg export) with **GitHub Actions cache** (`type=gha`). Fork PRs use read-only cache (`CACHE_GHA_RO`).
- **Cache verification:** second `web-image` bake must log ≥8 lines containing `CACHED`.
- **Taskfile.ci.yml** holds `ci:full` and `ci:docker`; root `task ci` delegates to `ci:full`.
- **Taskfile.docker.yml** holds Docker bake tasks (`docker:bake-ci`, etc.).
- Docs and `.gitignore` updated (`pkg-docker`, `dist-docker`).

## How to verify
- Open the PR and confirm the **CI** workflow passes (Docker build + `task ci:docker`).

Made with [Cursor](https://cursor.com)